### PR TITLE
Switch `MP_INCLUDE_DIR` to global property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,16 +30,16 @@ include("cmake/compat_config.cmake")
 include("cmake/pthread_checks.cmake")
 include(GNUInstallDirs)
 
-# Set convenience variables for subdirectories.
-set(MP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+# Set MP_INCLUDE_DIR as a global property so target_capnp_sources function can
+# use it, and its callers don't need to specify the include directory manually
+# to avoid "error: Import failed: /mp/proxy.capnp" failures from capnproto.
+set_property(GLOBAL PROPERTY MP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+# Set a convenience variable for subdirectories.
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(MP_STANDALONE TRUE)
   include(CTest)
 else()
-  # Set MP_INCLUDE_DIR for parent directories too, so target_capnp_sources calls
-  # in parent directories can use it and not need to specify include directories
-  # manually or see capnproto error "error: Import failed: /mp/proxy.capnp"
-  set(MP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include" PARENT_SCOPE)
   set(MP_STANDALONE FALSE)
 endif()
 

--- a/cmake/TargetCapnpSources.cmake
+++ b/cmake/TargetCapnpSources.cmake
@@ -72,11 +72,12 @@ function(target_capnp_sources target include_prefix)
     message(FATAL_ERROR "No usable mpgen. Set MPGEN_EXECUTABLE or enable the internal target.")
   endif()
 
+  get_property(mp_include_dir GLOBAL PROPERTY MP_INCLUDE_DIR)
   set(generated_headers "")
   foreach(capnp_file IN LISTS TCS_UNPARSED_ARGUMENTS)
     add_custom_command(
       OUTPUT ${capnp_file}.c++ ${capnp_file}.h ${capnp_file}.proxy-client.c++ ${capnp_file}.proxy-types.h ${capnp_file}.proxy-server.c++ ${capnp_file}.proxy-types.c++ ${capnp_file}.proxy.h
-      COMMAND ${MPGEN_BINARY} ${CMAKE_CURRENT_SOURCE_DIR} ${include_prefix} ${CMAKE_CURRENT_SOURCE_DIR}/${capnp_file} ${TCS_IMPORT_PATHS} ${MP_INCLUDE_DIR}
+      COMMAND ${MPGEN_BINARY} ${CMAKE_CURRENT_SOURCE_DIR} ${include_prefix} ${CMAKE_CURRENT_SOURCE_DIR}/${capnp_file} ${TCS_IMPORT_PATHS} ${mp_include_dir}
       DEPENDS ${capnp_file}
       VERBATIM
     )
@@ -97,7 +98,7 @@ function(target_capnp_sources target include_prefix)
   if(relative_path)
     string(APPEND build_include_prefix "/" "${relative_path}")
   endif()
-  target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${build_include_prefix}> ${MP_INCLUDE_DIR})
+  target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${build_include_prefix}> ${mp_include_dir})
 
   if(TARGET Libmultiprocess::multiprocess)
     target_link_libraries(${target} PRIVATE Libmultiprocess::multiprocess)


### PR DESCRIPTION
This PR automates handling of `MP_INCLUDE_DIR` in the `target_capnp_sources` function, removing the need to manually propagate it across directories for both this project and downstream projects.