### PR TITLE
cmake: Show error instead of invoking cross-compiled mpgen binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,17 @@ include(GNUInstallDirs)
 # to avoid "error: Import failed: /mp/proxy.capnp" failures from capnproto.
 set_property(GLOBAL PROPERTY MP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
+# Set MP_NO_GENERATE as a global property if cross compiling and
+# MPGEN_EXECUTABLE not set and cross compiled executables can not run. This
+# should trigger a more readable attempting to run a cross compiled executable.
+if(CMAKE_CROSSCOMPILING AND NOT MPGEN_EXECUTABLE)
+  include(CheckCXXSourceRuns)
+  check_cxx_source_runs("int main() { return 0; }" EXECUTABLES_CAN_RUN)
+  if(NOT EXECUTABLES_CAN_RUN)
+    set_property(GLOBAL PROPERTY MP_NO_GENERATE TRUE)
+  endif()
+endif()
+
 # Set a convenience variable for subdirectories.
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(MP_STANDALONE TRUE)

--- a/cmake/TargetCapnpSources.cmake
+++ b/cmake/TargetCapnpSources.cmake
@@ -73,14 +73,29 @@ function(target_capnp_sources target include_prefix)
   endif()
 
   get_property(mp_include_dir GLOBAL PROPERTY MP_INCLUDE_DIR)
+  get_property(mp_no_generate GLOBAL PROPERTY MP_NO_GENERATE)
   set(generated_headers "")
   foreach(capnp_file IN LISTS TCS_UNPARSED_ARGUMENTS)
-    add_custom_command(
-      OUTPUT ${capnp_file}.c++ ${capnp_file}.h ${capnp_file}.proxy-client.c++ ${capnp_file}.proxy-types.h ${capnp_file}.proxy-server.c++ ${capnp_file}.proxy-types.c++ ${capnp_file}.proxy.h
-      COMMAND ${MPGEN_BINARY} ${CMAKE_CURRENT_SOURCE_DIR} ${include_prefix} ${CMAKE_CURRENT_SOURCE_DIR}/${capnp_file} ${TCS_IMPORT_PATHS} ${mp_include_dir}
-      DEPENDS ${capnp_file}
-      VERBATIM
-    )
+    set(output_files ${capnp_file}.c++ ${capnp_file}.h ${capnp_file}.proxy-client.c++ ${capnp_file}.proxy-types.h ${capnp_file}.proxy-server.c++ ${capnp_file}.proxy-types.c++ ${capnp_file}.proxy.h)
+    if (mp_no_generate)
+      add_custom_command(
+        OUTPUT ${output_files}
+        COMMAND ${CMAKE_COMMAND} -E echo ""
+        COMMAND ${CMAKE_COMMAND} -E echo "ERROR: Cannot run cross-compiled ${MPGEN_BINARY} code generator on this system."
+        COMMAND ${CMAKE_COMMAND} -E echo "Please specify path to a native mpgen tool with MPGEN_EXECUTABLE option."
+        COMMAND ${CMAKE_COMMAND} -E echo ""
+        COMMAND ${CMAKE_COMMAND} -E false
+        VERBATIM
+      )
+    else()
+      add_custom_command(
+        OUTPUT ${output_files}
+        COMMAND ${MPGEN_BINARY} ${CMAKE_CURRENT_SOURCE_DIR} ${include_prefix} ${CMAKE_CURRENT_SOURCE_DIR}/${capnp_file} ${TCS_IMPORT_PATHS} ${mp_include_dir}
+        DEPENDS ${capnp_file}
+        VERBATIM
+      )
+    endif()
+
     target_sources(${target} PRIVATE
       ${CMAKE_CURRENT_BINARY_DIR}/${capnp_file}.c++
       ${CMAKE_CURRENT_BINARY_DIR}/${capnp_file}.proxy-client.c++


### PR DESCRIPTION
Idea here is to avoid potentially confusing errors if cross compiling and forgetting to set the MPGEN_EXECUTABLE.

Idea came from theuni in https://github.com/bitcoin/bitcoin/pull/31741#discussion_r2040214663 with suggestion to show a warning whenever CMAKE_CROSSCOMPILING was set and MPGEN_EXECUTABLE wasn't set, but this would show a warning in the default build which excludes tests and examples and does not need to run the code generator. Also it could warn spuriously if cross-compiled binaries were actually executable.

Avoid these problems by using check_cxx_source_runs instead of CMAKE_CROSSCOMPILING to see if binaries can run and triggering an error at build time instead of configure time to avoid showing warnings when code generator is not actually needed.

This is currently a draft PR, because I haven't tested it on a cross-compiled system so not actually sure it is a significant improvement. Also not sure if this is the best approach.