### PR TITLE
Set cmake_minimum_required(VERSION 3.22)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.22)
 
 project("Libmultiprocess" CXX)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/ci/configs/olddeps.bash
+++ b/ci/configs/olddeps.bash
@@ -4,5 +4,5 @@ CI_DIR=build-olddeps
 # requires an older GCC.
 NIXPKGS_CHANNEL=nixos-25.05
 export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
-NIX_ARGS=(--argstr capnprotoVersion "0.9.2" --argstr cmakeVersion "3.12.4" --argstr gccVersion "11")
+NIX_ARGS=(--argstr capnprotoVersion "0.9.2" --argstr cmakeVersion "3.22.6" --argstr gccVersion "11")
 BUILD_ARGS=(-k)

--- a/ci/scripts/ci.sh
+++ b/ci/scripts/ci.sh
@@ -18,20 +18,10 @@ fi
 [ -n "${CI_CLEAN-}" ] && rm -rf "${CI_DIR}"
 
 cmake --version
-cmake_ver=$(cmake --version | awk '/version/{print $3; exit}')
-ver_ge() { [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]; }
 
 src_dir=$PWD
 mkdir -p "$CI_DIR"
 cd "$CI_DIR"
 cmake "$src_dir" "${CMAKE_ARGS[@]+"${CMAKE_ARGS[@]}"}"
-if ver_ge "$cmake_ver" "3.15"; then
-  cmake --build . -t "${BUILD_TARGETS[@]}" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
-else
-  # Older versions of cmake can only build one target at a time with --target,
-  # and do not support -t shortcut
-  for t in "${BUILD_TARGETS[@]}"; do
-    cmake --build . --target "$t" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
-  done
-fi
+cmake --build . -t "${BUILD_TARGETS[@]}" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
 ctest --output-on-failure

--- a/shell.nix
+++ b/shell.nix
@@ -54,7 +54,7 @@ let
   clang = if enableLibcxx then llvm.libcxxClang else llvm.clang;
   clang-tools = llvm.clang-tools.override { inherit enableLibcxx; };
   cmakeHashes = {
-    "3.12.4" = "sha256-UlVYS/0EPrcXViz/iULUcvHA5GecSUHYS6raqbKOMZQ=";
+    "3.22.6" = "sha256-c5MxY2cOpOqVwjFUkAewxyQygik1BqLPRENxSCatXsM=";
   };
   gcc = if gccVersion == null then null else builtins.getAttr ("gcc" + gccVersion) pkgs;
   cmakeBuild = if cmakeVersion == null then pkgs.cmake else (pkgs.cmake.overrideAttrs (old: {


### PR DESCRIPTION
This PR is doing two different things:

* It is switching on cmake policies CMP0076-CMP0128
* It is triggering a fatal error if versions of cmake before 3.22 are used.

This is a follow-up to the last bump in https://github.com/bitcoin-core/libmultiprocess/pull/164.

It is unclear why effort should be made to try to support earlier cmake versions than the ones Bitcoin Core is using (https://github.com/bitcoin/bitcoin/blob/e486597f9a57903600656fb5106858941885852f/CMakeLists.txt#L10), because libmultiprocess is currently only used there.

Moreover, old systems shipping with ancient cmake versions are likely already incompatible due to https://github.com/bitcoin-core/libmultiprocess/pull/205, if they lack the appropriate point release of capnproto.

Once there is a need or use-case to derive from Bitcoin Core, the policy could be changed then.

Bumping the minimum could also unlock simpler cmake code, see https://github.com/bitcoin-core/libmultiprocess/pull/163#issuecomment-2886577273