### PR TITLE
build: require CapnProto 0.7.0 or better

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 include("cmake/compat_find.cmake")
 
-find_package(CapnProto REQUIRED)
+find_package(CapnProto 0.7.0 REQUIRED)
 find_package(Threads REQUIRED)
 
 set(MPGEN_EXECUTABLE "" CACHE FILEPATH "If specified, should be full path to an external mpgen binary to use rather than the one built internally.")


### PR DESCRIPTION
Although 1.0.1. is the oldest version currently covered by Bitcoin Core's extensive CI, Debian Bookwork ships 0.9.2 and #194 introduces test coverage for even older versions. 0.7 has been required since https://github.com/bitcoin-core/libmultiprocess/pull/88.

The CI run of https://github.com/Sjors/bitcoin/pull/100 @ [3d55222](https://github.com/Sjors/bitcoin/pull/100/checks?sha=3d552223712eed88d17e5ead1ef7d1ba6fd7e89e) previously checked Bitcoin Core CI against 1.0.1 as the minimum. Lowering the minimum further should not be a problem for that CI.