### PR TITLE
doc: correct the build instructions for the example

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -19,6 +19,9 @@ A simple interface description can be found at [test/mp/test/foo.capnp](../test/
 A more complete example can be found in [example](../example/) and run with:
 
 ```sh
-make -C build example
-build/example/mpexample
+mkdir build
+cd build
+cmake ..
+make mpexamples
+example/mpexample
 ```


### PR DESCRIPTION
The make target to build the example executable is "mpexample", not "example", so `make example` does nothing. This PR changes the documentation to use "mpexamples", because that builds the calculator, printer and example executables.