### PR TITLE
cmake: search capnproto in package mode only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 include("cmake/compat_find.cmake")
 
 find_package(Threads REQUIRED)
-find_package(CapnProto 0.7 REQUIRED)
+find_package(CapnProto 0.7 REQUIRED NO_MODULE)
 
 # Check for list-of-pointers memory access bug from Nov 2022
 # https://nvd.nist.gov/vuln/detail/CVE-2022-46149


### PR DESCRIPTION
CMake does not provide a `FindCapnProto.cmake` module and never will, because CapnProto already ships CMake package configuration files. Make sure to skip the search for the CMake module and avoid the confusing "By not providing ..." error message if CapnProto is not installed.

Current error message if CapnProto is not intalled:
```
CMake Error at CMakeLists.txt:16 (find_package):
  By not providing "FindCapnProto.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "CapnProto", but CMake did not find one.

  Could not find a package configuration file provided by "CapnProto"
  (requested version 0.7) with any of the following names:

    CapnProtoConfig.cmake
    capnproto-config.cmake

  Add the installation prefix of "CapnProto" to CMAKE_PREFIX_PATH or set
  "CapnProto_DIR" to a directory containing one of the above files.  If
  "CapnProto" provides a separate development package or SDK, be sure it has
  been installed.


-- Configuring incomplete, errors occurred!
```

with `NO_MODULE`:
```
CMake Error at CMakeLists.txt:16 (find_package):
  Could not find a package configuration file provided by "CapnProto"
  (requested version 0.7) with any of the following names:

    CapnProtoConfig.cmake
    capnproto-config.cmake

  Add the installation prefix of "CapnProto" to CMAKE_PREFIX_PATH or set
  "CapnProto_DIR" to a directory containing one of the above files.  If
  "CapnProto" provides a separate development package or SDK, be sure it has
  been installed.


-- Configuring incomplete, errors occurred!
```
