### PR TITLE
ci: Test minimum cmake version in olddeps job

### DIFF
--- a/ci/configs/olddeps.bash
+++ b/ci/configs/olddeps.bash
@@ -1,5 +1,5 @@
-CI_DESC="CI job using old Cap'n Proto version"
+CI_DESC="CI job using old Cap'n Proto and cmake versions"
 CI_DIR=build-olddeps
 export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
-NIX_ARGS=(--argstr capnprotoVersion "0.7.1")
+NIX_ARGS=(--argstr capnprotoVersion "0.7.1" --argstr cmakeVersion "3.12.4")
 BUILD_ARGS=(-k)

--- a/ci/scripts/ci.sh
+++ b/ci/scripts/ci.sh
@@ -18,7 +18,20 @@ fi
 [ -n "${CI_CLEAN-}" ] && rm -rf "${CI_DIR}"
 
 cmake --version
+cmake_ver=$(cmake --version | awk '/version/{print $3; exit}')
+ver_ge() { [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]; }
 
-cmake -B "$CI_DIR" "${CMAKE_ARGS[@]+"${CMAKE_ARGS[@]}"}"
-cmake --build "$CI_DIR" -t "${BUILD_TARGETS[@]}" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
-ctest --test-dir "$CI_DIR" --output-on-failure
+src_dir=$PWD
+mkdir -p "$CI_DIR"
+cd "$CI_DIR"
+cmake "$src_dir" "${CMAKE_ARGS[@]+"${CMAKE_ARGS[@]}"}"
+if ver_ge "$cmake_ver" "3.15"; then
+  cmake --build . -t "${BUILD_TARGETS[@]}" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
+else
+  # Older versions of cmake can only build one target at a time with --target,
+  # and do not support -t shortcut
+  for t in "${BUILD_TARGETS[@]}"; do
+    cmake --build . --target "$t" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
+  done
+fi
+ctest --output-on-failure


### PR DESCRIPTION
Add CI job to test minimum version of cmake that can be used to build. Current minimum version 3.12, since that's version that added c++20 support according to #164.