### PR TITLE
ci: add newdeps job testing newer versions of cmake and capnproto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           prepare: |
-            pkg install -y cmake ninja bash capnproto
+            pkg install -y cmake ninja bash capnproto git
           sync: 'rsync'
           copyback: false
 
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [default, llvm, gnu32, sanitize, olddeps]
+        config: [default, llvm, gnu32, sanitize, olddeps, newdeps]
 
     name: build • ${{ matrix.config }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           prepare: |
-            pkg install -y cmake ninja bash capnproto
+            pkg install -y cmake ninja bash capnproto git
           sync: 'rsync'
           copyback: false
 
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [default, llvm, gnu32, sanitize, olddeps]
+        config: [default, llvm, gnu32, sanitize, olddeps, newdeps]
 
     name: build • ${{ matrix.config }}
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -21,6 +21,7 @@ CI_CONFIG=ci/configs/llvm.bash     ci/scripts/run.sh
 CI_CONFIG=ci/configs/gnu32.bash    ci/scripts/run.sh
 CI_CONFIG=ci/configs/sanitize.bash ci/scripts/run.sh
 CI_CONFIG=ci/configs/olddeps.bash  ci/scripts/run.sh
+CI_CONFIG=ci/configs/newdeps.bash  ci/scripts/run.sh
 ```
 
 By default CI jobs will reuse their build directories. `CI_CLEAN=1` can be specified to delete them before running instead.

--- a/ci/configs/newdeps.bash
+++ b/ci/configs/newdeps.bash
@@ -1,0 +1,6 @@
+CI_DESC="CI job using newest Cap'n Proto and cmake versions"
+CI_DIR=build-newdeps
+export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
+CAPNP_CHECKOUT=master
+NIX_ARGS=(--argstr capnprotoVersion "none" --argstr cmakeVersion "4.1.1")
+BUILD_ARGS=(-k)

--- a/ci/configs/sanitize.bash
+++ b/ci/configs/sanitize.bash
@@ -3,5 +3,5 @@ CI_DIR=build-sanitize
 export CXX=clang++
 export CXXFLAGS="-ggdb -Werror -Wall -Wextra -Wpedantic -Wthread-safety-analysis -Wno-unused-parameter -fsanitize=thread"
 CMAKE_ARGS=()
-BUILD_ARGS=(-k -j4)
+BUILD_ARGS=(-k)
 BUILD_TARGETS=(mptest)

--- a/ci/scripts/ci.sh
+++ b/ci/scripts/ci.sh
@@ -41,14 +41,23 @@ src_dir=$PWD
 mkdir -p "$CI_DIR"
 cd "$CI_DIR"
 git --no-pager log -1 || true
-cmake "$src_dir" "${CMAKE_ARGS[@]+"${CMAKE_ARGS[@]}"}"
+cmake_args=("${CMAKE_ARGS[@]+"${CMAKE_ARGS[@]}"}")
+if ! cmake "$src_dir" "${cmake_args[@]}"; then
+  # If cmake failed, try it again with debug options.
+  # Could add --trace / --trace-expand here too but they are very verbose.
+  cmake_args+=(--debug-find --debug-output --debug-trycompile --log-level=DEBUG)
+  cmake "$src_dir" "${cmake_args[@]}" || : "cmake exited with $?"
+  cat CMakeFiles/CMakeConfigureLog.yaml || true
+  find . -ls || true
+  false
+fi
 if ver_ge "$cmake_ver" "3.15"; then
-  cmake --build . -t "${BUILD_TARGETS[@]}" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
+  cmake --build . --parallel -t "${BUILD_TARGETS[@]}" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
 else
   # Older versions of cmake can only build one target at a time with --target,
   # and do not support -t shortcut
   for t in "${BUILD_TARGETS[@]}"; do
-    cmake --build . --target "$t" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
+    cmake --build . --parallel --target "$t" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
   done
 fi
 ctest --output-on-failure

--- a/ci/scripts/ci.sh
+++ b/ci/scripts/ci.sh
@@ -21,10 +21,27 @@ cmake --version
 cmake_ver=$(cmake --version | awk '/version/{print $3; exit}')
 ver_ge() { [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]; }
 
+# If CAPNP_CHECKOUT was requested, clone and install requested Cap'n Proto branch or tag
+capnp_prefix=
+if [ -n "${CAPNP_CHECKOUT-}" ]; then
+  capnp_prefix="$PWD/capnp-install"
+  [ -e "capnp" ] || git clone -b "${CAPNP_CHECKOUT}" "https://github.com/capnproto/capnproto" capnp
+  mkdir -p capnp/build
+  (
+    cd capnp/build
+    git --no-pager log -1 || true
+    CXXFLAGS="-std=c++20" cmake .. "-DCMAKE_INSTALL_PREFIX=${capnp_prefix}" -DBUILD_TESTING=OFF -DWITH_OPENSSL=OFF -DWITH_ZLIB=OFF
+    cmake --build .
+    cmake --install .
+  )
+  export CMAKE_PREFIX_PATH="${capnp_prefix}:${CMAKE_PREFIX_PATH-}"
+fi
+
 src_dir=$PWD
 mkdir -p "$CI_DIR"
 cd "$CI_DIR"
 export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+git --no-pager log -1 || true
 cmake "$src_dir" "${CMAKE_ARGS[@]+"${CMAKE_ARGS[@]}"}"
 if ver_ge "$cmake_ver" "3.15"; then
   cmake --build . -t "${BUILD_TARGETS[@]}" -- "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"

--- a/shell.nix
+++ b/shell.nix
@@ -40,6 +40,7 @@ let
   clang-tools = llvm.clang-tools.override { inherit enableLibcxx; };
   cmakeHashes = {
     "3.12.4" = "sha256-UlVYS/0EPrcXViz/iULUcvHA5GecSUHYS6raqbKOMZQ=";
+    "4.1.1" = "sha256-sp9vGXM6oiS3djUHoQikJ+1Ixojh+vIrKcROHDBUkoI=";
   };
   cmakeBuild = if cmakeVersion == null then pkgs.cmake else (pkgs.cmake.overrideAttrs (old: {
     version = cmakeVersion;
@@ -50,11 +51,12 @@ let
     patches = [];
   })).override { isMinimalBuild = true; };
 in crossPkgs.mkShell {
-  buildInputs = [
+  buildInputs = lib.optionals (capnprotoVersion != "none") [
     capnproto
   ];
   nativeBuildInputs = with pkgs; [
     cmakeBuild
+    git
     include-what-you-use
     ninja
   ] ++ lib.optionals (!minimal) [
@@ -64,4 +66,7 @@ in crossPkgs.mkShell {
 
   # Tell IWYU where its libc++ mapping lives
   IWYU_MAPPING_FILE = if enableLibcxx then "${llvm.libcxx.dev}/include/c++/v1/libcxx.imp" else null;
+
+  # Avoid "SSL certificate problem: unable to get local issuer certificate" error during git clone in ci/scripts/ci.sh
+  NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -55,6 +55,7 @@ let
   clang-tools = llvm.clang-tools.override { inherit enableLibcxx; };
   cmakeHashes = {
     "3.12.4" = "sha256-UlVYS/0EPrcXViz/iULUcvHA5GecSUHYS6raqbKOMZQ=";
+    "4.1.1" = "sha256-sp9vGXM6oiS3djUHoQikJ+1Ixojh+vIrKcROHDBUkoI=";
   };
   gcc = if gccVersion == null then null else builtins.getAttr ("gcc" + gccVersion) pkgs;
   cmakeBuild = if cmakeVersion == null then pkgs.cmake else (pkgs.cmake.overrideAttrs (old: {
@@ -66,11 +67,12 @@ let
     patches = [];
   })).override { isMinimalBuild = true; };
 in crossPkgs.mkShell {
-  buildInputs = [
+  buildInputs = lib.optionals (capnprotoVersion != "none") [
     capnproto
   ];
   nativeBuildInputs = with pkgs; [
     cmakeBuild
+    git
     include-what-you-use
     ninja
   ] ++ lib.optional (gcc != null) gcc ++ lib.optionals (!minimal) [
@@ -83,4 +85,7 @@ in crossPkgs.mkShell {
 
   # Tell IWYU where its libc++ mapping lives
   IWYU_MAPPING_FILE = if enableLibcxx then "${llvm.libcxx.dev}/include/c++/v1/libcxx.imp" else null;
+
+  # Avoid "SSL certificate problem: unable to get local issuer certificate" error during git clone in ci/scripts/ci.sh
+  NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 }


### PR DESCRIPTION
Add CI job testing latest released version of cmake, and latest unreleased version of cap'n proto to uncover any problems there may be with new releases. Use git version of cap'n proto because we've submitted patches to that project to fix issues in the past, so it would be good to know about any new issues as soon as possible.