### PR TITLE
test default PassField impl handles output parameters

### DIFF
--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -13,6 +13,7 @@ $Proxy.includeTypes("mp/test/foo-types.h");
 
 interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     add @0 (a :Int32, b :Int32) -> (result :Int32);
+    addOut @19 (a :Int32, b :Int32) -> (ret :Int32);
     mapSize @1 (map :List(Pair(Text, Text))) -> (result :Int32);
     pass @2 (arg :FooStruct) -> (result :FooStruct);
     raise @3 (arg :FooStruct) -> (error :FooStruct $Proxy.exception("mp::test::FooStruct"));

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -14,6 +14,7 @@ $Proxy.includeTypes("mp/test/foo-types.h");
 interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     add @0 (a :Int32, b :Int32) -> (result :Int32);
     addOut @19 (a :Int32, b :Int32) -> (ret :Int32);
+    addInOut @20 (x :Int32, sum :Int32) -> (sum :Int32);
     mapSize @1 (map :List(Pair(Text, Text))) -> (result :Int32);
     pass @2 (arg :FooStruct) -> (result :FooStruct);
     raise @3 (arg :FooStruct) -> (error :FooStruct $Proxy.exception("mp::test::FooStruct"));

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -63,6 +63,7 @@ class FooImplementation
 public:
     int add(int a, int b) { return a + b; }
     void addOut(int a, int b, int& out) { out = a + b; }
+    void addInOut(int x, int& sum) { sum += x; }
     int mapSize(const std::map<std::string, std::string>& map) { return map.size(); }
     FooStruct pass(FooStruct foo) { return foo; }
     void raise(FooStruct foo) { throw foo; }

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -62,6 +62,7 @@ class FooImplementation
 {
 public:
     int add(int a, int b) { return a + b; }
+    void addOut(int a, int b, int& out) { out = a + b; }
     int mapSize(const std::map<std::string, std::string>& map) { return map.size(); }
     FooStruct pass(FooStruct foo) { return foo; }
     void raise(FooStruct foo) { throw foo; }

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -116,6 +116,8 @@ KJ_TEST("Call FooInterface methods")
     int ret;
     foo->addOut(3, 4, ret);
     KJ_EXPECT(ret == 7);
+    foo->addInOut(3, ret);
+    KJ_EXPECT(ret == 10);
 
     FooStruct in;
     in.name = "name";

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -113,6 +113,9 @@ KJ_TEST("Call FooInterface methods")
     ProxyClient<messages::FooInterface>* foo = setup.client.get();
 
     KJ_EXPECT(foo->add(1, 2) == 3);
+    int ret;
+    foo->addOut(3, 4, ret);
+    KJ_EXPECT(ret == 7);
 
     FooStruct in;
     in.name = "name";


### PR DESCRIPTION
This PR adds two test cases to ensure that output parameter results from a server call are correctly captured and included in the response.
The new tests also serve as practical examples of how to work with output parameters and `in|out` parameters in the codebase.

### Testing
Automated coverage is not yet available, see https://github.com/bitcoin-core/libmultiprocess/issues/198.

As a temporary verification method:

- Comment out [these lines](https://github.com/bitcoin-core/libmultiprocess/blob/47d79db8a5528097b408e18f7b0bae11a6702d26/include/mp/proxy-types.h#L308-L310)
 and run make check. The new test should fail, confirming it is effective.

- If you then also comment out the newly added tests and rerun make check, it should pass, demonstrating that the lines above were previously uncovered.