### PR TITLE
Improve and document act support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      NIX_EXTRA_CONFIG_ACT: |
+        sandbox = false
+        filter-syscalls = false
+
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +95,10 @@ jobs:
         uses: cachix/install-nix-action@v31       # 2025-05-27, from https://github.com/cachix/install-nix-action/tags
         with:
           nix_path: nixpkgs=channel:nixos-25.05   # latest release
+          # Act executes inside an unprivileged container (Docker or Podman),
+          # so KVM support isn't available.
+          enable_kvm: "${{ github.actor != 'nektos/act' }}"
+          extra_nix_config: ${{ github.actor == 'nektos/act' && env.NIX_EXTRA_CONFIG_ACT || '' }}
 
       - name: Run CI script
         env:

--- a/ci/README.md
+++ b/ci/README.md
@@ -24,3 +24,29 @@ CI_CONFIG=ci/configs/olddeps.bash  ci/scripts/run.sh
 ```
 
 By default CI jobs will reuse their build directories. `CI_CLEAN=1` can be specified to delete them before running instead.
+
+### Running workflows with `act`
+
+You can run either the entire workflow or a single matrix entry locally. On
+macOS or Linux:
+
+1. Install [`act`](https://github.com/nektos/act) and either Docker or
+  Podman.
+2. Inside the Podman VM, create a named volume for the Nix store (ext4,
+  case-sensitive) so builds persist across runs. Recreate it any time you want
+  a clean cache:
+  ```bash
+  podman volume create libmultiprocess-nix
+  ```
+3. From the repo root, launch the workflow. The example below targets the
+  sanitize matrix entry; drop the `--matrix` flag to run every configuration.
+  ```bash
+  act \
+    --reuse \
+    -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-24.04 \
+    --container-options "-v libmultiprocess-nix:/nix" \
+    -j build \
+    --matrix config:sanitize
+  ```
+
+


### PR DESCRIPTION
Facilitate using [act](https://github.com/nektos/act) with Docker / Podman as an alternative for using nix directly.

I found this very useful for testing the sanitizer job against individual commits in #222. That is, once I finally got it to work... 