### PR TITLE
mpgen: emit return value after output parameters

### DIFF
--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -524,8 +524,8 @@ static void Generate(kj::StringPtr src_prefix,
                 std::ostringstream server_invoke_start;
                 std::ostringstream server_invoke_end;
                 int argc = 0;
-                for (const auto& field : fields) {
-                    if (field.skip) continue;
+                auto build_field = [&](const Field& field) {
+                    if (field.skip) return;
 
                     const auto& f = field.param_is_set ? field.param : field.result;
                     auto field_name = f.getProto().getName();
@@ -589,6 +589,16 @@ static void Generate(kj::StringPtr src_prefix,
                     server_invoke_start << ", Accessor<" << base_name << "_fields::" << Cap(field_name) << ", "
                                         << field_flags.str() << ">>(";
                     server_invoke_end << ")";
+                };
+
+                for (const auto& field : fields) {
+                    if (!field.retval) build_field(field);
+                }
+                // C++ return values appear after all method parameters in FunctionTraits.
+                // Keep this order even when the Cap'n Proto result field is declared
+                // earlier for wire compatibility.
+                for (const auto& field : fields) {
+                    if (field.retval) build_field(field);
                 }
 
                 const std::string static_str{is_construct || is_destroy ? "static " : ""};

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -15,6 +15,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     add @0 (a :Int32, b :Int32) -> (result :Int32);
     addOut @19 (a :Int32, b :Int32) -> (ret :Int32);
     addInOut @20 (x :Int32, sum :Int32) -> (sum :Int32);
+    addResultOut @23 (value :Int32) -> (result :Int32, text :Text);
     mapSize @1 (map :List(Pair(Text, Text))) -> (result :Int32);
     pass @2 (arg :FooStruct) -> (result :FooStruct);
     raise @3 (arg :FooStruct) -> (error :FooStruct $Proxy.exception("mp::test::FooStruct"));

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -67,6 +67,7 @@ public:
     int add(int a, int b) { return a + b; }
     void addOut(int a, int b, int& out) { out = a + b; }
     void addInOut(int x, int& sum) { sum += x; }
+    int addResultOut(int value, std::string& text) { text = std::to_string(value); return value + 1; }
     int mapSize(const std::map<std::string, std::string>& map) { return map.size(); }
     FooStruct pass(FooStruct foo) { return foo; }
     void raise(FooStruct foo) { throw foo; }

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -138,6 +138,9 @@ KJ_TEST("Call FooInterface methods")
     KJ_EXPECT(ret == 7);
     foo->addInOut(3, ret);
     KJ_EXPECT(ret == 10);
+    std::string text;
+    KJ_EXPECT(foo->addResultOut(41, text) == 42);
+    KJ_EXPECT(text == "41");
 
     FooStruct in;
     in.name = "name";


### PR DESCRIPTION
Disclaimer: I am not very familiar with this codebase, so I would appreciate feedback on whether this is a desirable change, or if there is a preferred way to handle this case.

This PR updates proxy generation for methods where the Cap’n Proto `result` field is declared before other output fields, but the corresponding C++ method has output parameters before its return value.

A concrete example is Bitcoin Core’s `BlockTemplate.submitSolution` IPC method. It currently returns:

```text
submitSolution (...) -> (result: Bool);
```

But if we need to  add rejection details:

```text
submitSolution (...) -> (result: Bool, reason: Text, debug: Text);
```

The `result` field needs to stay first to preserve the existing wire field number for compatibility. But the C++ method naturally looks like:

```c++
bool submitSolution(..., std::string& reason, std::string& debug);
```

The issue is that the Cap’n Proto field order would be `result, reason, debug`, but the corresponding C++ order is `reason, debug, result`: `reason` and `debug` are output parameters, while `result` is the method return value. Current `mpgen` output follows the Cap’n Proto order, so it generates C++ code that passes the fields in the wrong order for this method signature.

This PR changes `mpgen` to emit non-return fields first, then emit the `result` return-value field last. That keeps Cap’n Proto schema order independent from C++ invocation order, allowing schemas to preserve wire compatibility while still mapping correctly to C++ signatures.

The test changes add a regression method:

```text
addResultOut @23 (value :Int32) -> (result :Int32, text :Text);
```

mapped to:

```text
int addResultOut(int value, std::string& text);
```

The test verifies both the C++ return value and output parameter are transmitted correctly.