### PR TITLE
Add ReadList helper

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -291,6 +291,21 @@ void BuildList(TypeList<LocalType>, InvokeContext& invoke_context, Output&& outp
     }
 }
 
+template <typename LocalType, typename Input, typename ReadDest, typename InitFn, typename EmplaceFn>
+decltype(auto) ReadList(TypeList<LocalType>, InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest, InitFn&& init, EmplaceFn&& emplace)
+{
+    return read_dest.update([&](auto& value) {
+        auto data = input.get();
+        init(value, data.size());
+        for (auto item : data) {
+            ReadField(TypeList<LocalType>(), invoke_context, Make<ValueField>(item),
+                      ReadDestEmplace(TypeList<LocalType>(), [&emplace, &value](auto&&... args) -> decltype(auto) {
+                          return emplace(value, std::forward<decltype(args)>(args)...);
+                      }));
+        }
+    });
+}
+
 template <typename LocalType, typename Value, typename Output>
 void CustomBuildField(TypeList<LocalType>, Priority<0>, InvokeContext& invoke_context, Value&& value, Output&& output)
 {

--- a/include/mp/type-map.h
+++ b/include/mp/type-map.h
@@ -56,18 +56,12 @@ decltype(auto) CustomReadField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
     Input&& input,
     ReadDest&& read_dest)
 {
-    return read_dest.update([&](auto& value) {
-        auto data = input.get();
-        value.clear();
-        for (auto item : data) {
-            ReadField(TypeList<std::pair<const KeyLocalType, ValueLocalType>>(), invoke_context,
-                Make<ValueField>(item),
-                ReadDestEmplace(
-                    TypeList<std::pair<const KeyLocalType, ValueLocalType>>(), [&](auto&&... args) -> auto& {
-                        return *EmplacePiecewiseSafe(value, std::forward<decltype(args)>(args)...).first;
-                    }));
-        }
-    });
+    return ReadList(
+        TypeList<std::pair<const KeyLocalType, ValueLocalType>>(), invoke_context, input, read_dest,
+        [&](auto& value, size_t) { value.clear(); },
+        [&](auto& value, auto&&... args) -> auto& {
+            return *EmplacePiecewiseSafe(value, std::forward<decltype(args)>(args)...).first;
+        });
 }
 } // namespace mp
 

--- a/include/mp/type-set.h
+++ b/include/mp/type-set.h
@@ -26,16 +26,12 @@ decltype(auto) CustomReadField(TypeList<std::set<LocalType>>,
     Input&& input,
     ReadDest&& read_dest)
 {
-    return read_dest.update([&](auto& value) {
-        auto data = input.get();
-        value.clear();
-        for (auto item : data) {
-            ReadField(TypeList<LocalType>(), invoke_context, Make<ValueField>(item),
-                ReadDestEmplace(TypeList<const LocalType>(), [&](auto&&... args) -> auto& {
-                    return *value.emplace(std::forward<decltype(args)>(args)...).first;
-                }));
-        }
-    });
+    return ReadList(
+        TypeList<LocalType>(), invoke_context, input, read_dest,
+        [&](auto& value, size_t) { value.clear(); },
+        [&](auto& value, auto&&... args) -> auto& {
+            return *value.emplace(std::forward<decltype(args)>(args)...).first;
+        });
 }
 } // namespace mp
 

--- a/include/mp/type-unordered-set.h
+++ b/include/mp/type-unordered-set.h
@@ -27,16 +27,14 @@ decltype(auto) CustomReadField(TypeList<std::unordered_set<LocalType>>,
     Input&& input,
     ReadDest&& read_dest)
 {
-    return read_dest.update([&](auto& value) {
-        auto data = input.get();
-        value.clear();
-        for (auto item : data) {
-            ReadField(TypeList<LocalType>(), invoke_context, Make<ValueField>(item),
-                ReadDestEmplace(TypeList<const LocalType>(), [&](auto&&... args) -> auto& {
-                    return *value.emplace(std::forward<decltype(args)>(args)...).first;
-                }));
-        }
-    });
+    return ReadList(
+        TypeList<LocalType>(), invoke_context, input, read_dest,
+        [&](auto& value, size_t) {
+            value.clear();
+        },
+        [&](auto& value, auto&&... args) -> auto& {
+            return *value.emplace(std::forward<decltype(args)>(args)...).first;
+        });
 }
 } // namespace mp
 

--- a/include/mp/type-unordered-set.h
+++ b/include/mp/type-unordered-set.h
@@ -29,8 +29,9 @@ decltype(auto) CustomReadField(TypeList<std::unordered_set<LocalType>>,
 {
     return ReadList(
         TypeList<LocalType>(), invoke_context, input, read_dest,
-        [&](auto& value, size_t) {
+        [&](auto& value, size_t size) {
             value.clear();
+            value.reserve(size);
         },
         [&](auto& value, auto&&... args) -> auto& {
             return *value.emplace(std::forward<decltype(args)>(args)...).first;

--- a/include/mp/type-vector.h
+++ b/include/mp/type-vector.h
@@ -31,35 +31,16 @@ decltype(auto) CustomReadField(TypeList<std::vector<LocalType>>,
     Input&& input,
     ReadDest&& read_dest)
 {
-    return read_dest.update([&](auto& value) {
-        auto data = input.get();
-        value.clear();
-        value.reserve(data.size());
-        for (auto item : data) {
-            ReadField(TypeList<LocalType>(), invoke_context, Make<ValueField>(item),
-                ReadDestEmplace(TypeList<LocalType>(), [&](auto&&... args) -> auto& {
-                    value.emplace_back(std::forward<decltype(args)>(args)...);
-                    return value.back();
-                }));
-        }
-    });
-}
-
-template <typename Input, typename ReadDest>
-decltype(auto) CustomReadField(TypeList<std::vector<bool>>,
-                               Priority<1>,
-                               InvokeContext& invoke_context,
-                               Input&& input,
-                               ReadDest&& read_dest)
-{
-    return read_dest.update([&](auto& value) {
-        auto data = input.get();
-        value.clear();
-        value.reserve(data.size());
-        for (auto item : data) {
-            value.push_back(ReadField(TypeList<bool>(), invoke_context, Make<ValueField>(item), ReadDestTemp<bool>()));
-        }
-    });
+    return ReadList(
+        TypeList<LocalType>(), invoke_context, input, read_dest,
+        [&](auto& value, size_t size) {
+            value.clear();
+            value.reserve(size);
+        },
+        [&](auto& value, auto&&... args) -> decltype(auto) {
+            value.emplace_back(std::forward<decltype(args)>(args)...);
+            return value.back();
+        });
 }
 } // namespace mp
 


### PR DESCRIPTION
Follow up of https://github.com/bitcoin-core/libmultiprocess/pull/277#pullrequestreview-4412854098. This adds `ReadList` helper  and uses it to dedup the `CustomReadField` implementations for `std::map`, `std::set`, `std::unordered_set`, and `std::vector`, mirroring the existing `BuildList` helper on the build side.

I took the liberty of adding the commit f2a734a9c1515435743bba0fb9ef889687fc391c "type: reserve first when reading std::unordered_set" so it reserves the correct capacity first and then emplaces the values.