### PR TITLE
proxy: fix BuildList to use non-const iteration for interface types

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -285,9 +285,28 @@ void BuildList(TypeList<LocalType>, InvokeContext& invoke_context, Output&& outp
 {
     auto list = output.init(value.size());
     size_t i = 0;
-    for (const auto& elem : value) {
-        BuildField(TypeList<LocalType>(), invoke_context, ListOutput<typename decltype(list)::Builds>(list, i), elem);
-        ++i;
+    // Iterate with an explicit iterator rather than a range-for loop so the
+    // value category of `*it` is passed through to BuildField unchanged. This
+    // matters for two reasons:
+    //
+    // - Elements must be passed as non-const so that BuildField can move out of
+    //   them, e.g. calling unique_ptr::release() to transfer ownership of an
+    //   interface pointer to the capnp server.
+    //
+    // - For proxy containers like std::vector<bool>, `*it` is a prvalue proxy
+    //   object rather than a reference. A range-for loop would bind it to a
+    //   named variable and demote it to an lvalue; passing `*it` directly
+    //   preserves the prvalue-ness.
+    //
+    // Only move out of elements when `value` itself is an rvalue container that
+    // is about to be destroyed. When it is an lvalue reference owned by the
+    // caller, pass elements as lvalues so BuildField does not move from them.
+    for (auto it = value.begin(); it != value.end(); ++it, ++i) {
+        if constexpr (std::is_lvalue_reference_v<Value&&>) {
+            BuildField(TypeList<LocalType>(), invoke_context, ListOutput<typename decltype(list)::Builds>(list, i), *it);
+        } else {
+            BuildField(TypeList<LocalType>(), invoke_context, ListOutput<typename decltype(list)::Builds>(list, i), std::move(*it));
+        }
     }
 }
 

--- a/include/mp/type-map.h
+++ b/include/mp/type-map.h
@@ -9,6 +9,8 @@
 #include <mp/type-pair.h>
 #include <mp/util.h>
 
+#include <map>
+
 namespace mp {
 template <typename KeyLocalType, typename ValueLocalType, typename Value, typename Output>
 void CustomBuildField(TypeList<std::map<KeyLocalType, ValueLocalType>>,

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -329,6 +329,7 @@ static void Generate(kj::StringPtr src_prefix,
     cpp_client << "#include <kj/common.h>\n";
     cpp_client << "#include <map>\n";
     cpp_client << "#include <mp/proxy.h>\n";
+    cpp_client << "#include <mp/proxy-io.h>\n";
     cpp_client << "#include <mp/util.h>\n";
     cpp_client << "#include <string>\n";
     cpp_client << "#include <vector>\n";

--- a/test/mp/test/foo-types.h
+++ b/test/mp/test/foo-types.h
@@ -39,6 +39,7 @@ struct ExtendedCallback; // IWYU pragma: export
 struct FooCallback; // IWYU pragma: export
 struct FooFn; // IWYU pragma: export
 struct FooInterface; // IWYU pragma: export
+struct BarInterface; // IWYU pragma: export
 } // namespace messages
 
 template <typename Output>

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -37,6 +37,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     callFnAsync @18 (context :Proxy.Context) -> ();
     callIntFnAsync @21 (context :Proxy.Context, arg :Int32) -> (result :Int32);
     passDataPointers @22 (arg :List(Data)) -> (result :List(Data));
+    listBars @25 (context :Proxy.Context, n :Int32) -> (result :List(BarInterface));
 }
 
 interface FooInit $Proxy.wrap("mp::test::FooInit") {
@@ -50,6 +51,11 @@ interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
 
 interface ExtendedCallback extends(FooCallback) $Proxy.wrap("mp::test::ExtendedCallback") {
     callExtended @0 (context :Proxy.Context, arg :Int32) -> (result :Int32);
+}
+
+interface BarInterface $Proxy.wrap("mp::test::Bar") {
+    destroy @0 (context :Proxy.Context) -> ();
+    value @1 (context :Proxy.Context) -> (result :Int32);
 }
 
 interface FooFn $Proxy.wrap("ProxyCallback<std::function<int()>>") {

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -37,6 +37,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     callFnAsync @18 (context :Proxy.Context) -> ();
     callIntFnAsync @21 (context :Proxy.Context, arg :Int32) -> (result :Int32);
     passDataPointers @22 (arg :List(Data)) -> (result :List(Data));
+    listBars @25 (context :Proxy.Context, n :Int32) -> (result :List(BarInterface));
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
@@ -46,6 +47,11 @@ interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
 
 interface ExtendedCallback extends(FooCallback) $Proxy.wrap("mp::test::ExtendedCallback") {
     callExtended @0 (context :Proxy.Context, arg :Int32) -> (result :Int32);
+}
+
+interface BarInterface $Proxy.wrap("mp::test::Bar") {
+    destroy @0 (context :Proxy.Context) -> ();
+    value @1 (context :Proxy.Context) -> (result :Int32);
 }
 
 interface FooFn $Proxy.wrap("ProxyCallback<std::function<int()>>") {

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -71,6 +71,23 @@ class FooInit
 {
 };
 
+//! A second, arbitrary interface used to test returning a
+//! list of interface objects.
+class Bar
+{
+public:
+    virtual ~Bar() = default;
+    virtual int value() = 0;
+};
+
+//! Concrete Bar that returns a fixed value, used by listBars tests.
+class SimpleBar : public Bar
+{
+public:
+    explicit SimpleBar(int value) : m_value(value) {}
+    int value() override { return m_value; }
+    int m_value;
+};
 class FooImplementation
 {
 public:
@@ -96,6 +113,13 @@ public:
     double passDouble(double value) { return value; }
     int passFn(std::function<int()> fn) { return fn(); }
     std::vector<FooDataRef> passDataPointers(std::vector<FooDataRef> values) { return values; }
+    std::vector<std::unique_ptr<Bar>> listBars(int n)
+    {
+        std::vector<std::unique_ptr<Bar>> result;
+        result.reserve(n);
+        for (int i = 0; i < n; ++i) result.push_back(std::make_unique<SimpleBar>(i));
+        return result;
+    }
     std::shared_ptr<FooCallback> m_callback;
     void callFn() { assert(m_fn); m_fn(); }
     void callFnAsync() { assert(m_fn); m_fn(); }

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -66,6 +66,24 @@ public:
     virtual int callExtended(int arg) = 0;
 };
 
+//! A second, arbitrary interface used to test returning a
+//! list of interface objects.
+class Bar
+{
+public:
+    virtual ~Bar() = default;
+    virtual int value() = 0;
+};
+
+//! Concrete Bar that returns a fixed value, used by listBars tests.
+class SimpleBar : public Bar
+{
+public:
+    explicit SimpleBar(int value) : m_value(value) {}
+    int value() override { return m_value; }
+    int m_value;
+};
+
 class FooImplementation
 {
 public:
@@ -91,6 +109,13 @@ public:
     double passDouble(double value) { return value; }
     int passFn(std::function<int()> fn) { return fn(); }
     std::vector<FooDataRef> passDataPointers(std::vector<FooDataRef> values) { return values; }
+    std::vector<std::unique_ptr<Bar>> listBars(int n)
+    {
+        std::vector<std::unique_ptr<Bar>> result;
+        result.reserve(n);
+        for (int i = 0; i < n; ++i) result.push_back(std::make_unique<SimpleBar>(i));
+        return result;
+    }
     std::shared_ptr<FooCallback> m_callback;
     void callFn() { assert(m_fn); m_fn(); }
     void callFnAsync() { assert(m_fn); m_fn(); }

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -272,6 +272,16 @@ KJ_TEST("Call FooInterface methods")
     KJ_REQUIRE(data_out[0] != nullptr);
     KJ_EXPECT(*data_out[0] == *data_in[0]);
     KJ_EXPECT(!data_out[1]);
+
+    // Test returning vector<unique_ptr<interface>> from server. This exercises
+    // BuildList with interface element types, which requires non-const iteration
+    // so unique_ptr::release() can transfer ownership to the proxy server.
+    std::vector<std::unique_ptr<Bar>> bars{foo->listBars(3)};
+    KJ_REQUIRE(bars.size() == 3u);
+    for (int i = 0; i < 3; ++i) {
+        KJ_REQUIRE(bars[i] != nullptr);
+        KJ_EXPECT(bars[i]->value() == i);
+    }
 }
 
 KJ_TEST("Call IPC method after client connection is closed")

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -269,6 +269,16 @@ KJ_TEST("Call FooInterface methods")
     KJ_REQUIRE(data_out[0] != nullptr);
     KJ_EXPECT(*data_out[0] == *data_in[0]);
     KJ_EXPECT(!data_out[1]);
+
+    // Test returning vector<unique_ptr<interface>> from server. This exercises
+    // BuildList with interface element types, which requires non-const iteration
+    // so unique_ptr::release() can transfer ownership to the proxy server.
+    std::vector<std::unique_ptr<Bar>> bars{foo->listBars(3)};
+    KJ_REQUIRE(bars.size() == 3u);
+    for (int i = 0; i < 3; ++i) {
+        KJ_REQUIRE(bars[i] != nullptr);
+        KJ_EXPECT(bars[i]->value() == i);
+    }
 }
 
 KJ_TEST("Call IPC method after client connection is closed")


### PR DESCRIPTION
Needed for bitcoin/bitcoin#10102 since #277 was merged.

Since #277, it is no longer possible to return `vector<unique_ptr<ExternalSigner>>` from `Node::listExternalSigners()` in bitcoin/bitcoin#10102, because the proxy server objects libmultiprocess creates to wrap the `ExternalSigner` objects need to take ownership of the objects to keep them alive, so they need to be moved out of the returned vector, which can only be done if `BuildField` is passed a non-const vector element.

This PR restores previous behavior before #277 making it possible to mutate container elements while serializing them, in cases like this where it is necessary.
