### PR TITLE
Export compile_commands.json in standalone builds (by default) 

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,6 @@
+# Point clangd at the compile database in the build directory suggested by
+# doc/install.md. clangd only searches ancestor directories by default, so
+# without this a symlink to compile_commands.json would be needed in the
+# source directory.
+CompileFlags:
+  CompilationDatabase: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ project("Libmultiprocess" CXX)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED YES)
+  # Export compile_commands.json for clangd and other tooling, unless the
+  # -D option or environment variable was set explicitly (empty means unset).
+  if("${CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "")
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+  endif()
 endif()
 
 include("cmake/compat_find.cmake")


### PR DESCRIPTION
This makes the default build configuration play nicely with code editors. E.g. with Zed, looking at `spawn_argv` in #231:

Before:
<img width="1025" height="426" alt="before" src="https://github.com/user-attachments/assets/3b9881fd-7be2-49de-9180-b8517dda0394" />

After:
<img width="911" height="427" alt="after" src="https://github.com/user-attachments/assets/42bac960-3d31-4bf4-9d42-7d92b72c13a9" />

One downside of this approach is that it only just works(tm) on the `build` directory.

There are several alternative approaches:

1. Update documentation to recommend:

```
cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
ln -sf build/compile_commands.json .
```

2. Have cmake add a symlink to the source dir
3. Add a (dev) cmake preset