### PR TITLE
workaround: MinGW thread_local use-after-free in ThreadContext

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -929,12 +929,7 @@ void ListenConnections(EventLoop& loop, SocketId fd, InitImpl& init, std::option
     });
 }
 
-extern thread_local ThreadContext g_thread_context; // NOLINT(bitcoin-nontrivial-threadlocal)
-// Silence nonstandard bitcoin tidy error "Variable with non-trivial destructor
-// cannot be thread_local" which should not be a problem on modern platforms, and
-// could lead to a small memory leak at worst on older ones.
-
-//! Return the current thread's ThreadContext.
+//! Return the current thread's ThreadContext, creating it on first use.
 //!
 //! Why per-thread state is needed at all: libmultiprocess has no control over
 //! which threads the C++ application uses to call ProxyClient methods after
@@ -951,7 +946,60 @@ extern thread_local ThreadContext g_thread_context; // NOLINT(bitcoin-nontrivial
 //! are freed. A thread_local object is the C++ mechanism that provides both
 //! of these: per-thread storage plus a destructor that runs at thread exit
 //! (the C equivalent would be a pthread key destructor). This is why
-//! ThreadContext is thread_local and why its destructor is nontrivial.
+//! ThreadContext is thread_local and why its destructor is nontrivial —
+//! which is what makes the MinGW bug below bite here.
+//!
+//! It is normally an ordinary function-local thread_local object destroyed at
+//! thread exit, except on MinGW, where it is a lazily-created heap object
+//! that is deliberately leaked (held by a trivially-destructible thread_local
+//! pointer, so no destructor is registered at thread exit at all). Note that
+//! on MinGW this skips more than freeing memory: releasing the remote Thread
+//! capabilities at client-thread exit is what lets the server destroy that
+//! thread's dedicated server threads, so with the workaround, server threads
+//! belonging to exited client threads are only freed when the connection
+//! closes (via the disconnect cleanup callbacks registered in SetThread /
+//! ProxyClient<Thread>::m_disconnect_cb).
+//!
+//! The MinGW workaround exists because MinGW-w64's emutls implementation can
+//! free the heap storage backing thread_local variables before the C++
+//! destructors registered via __cxa_thread_atexit run at thread exit. Both
+//! cleanups are implemented as winpthreads pthread key destructors (run by
+//! _pthread_cleanup_dest in winpthreads src/thread.c), and pthread key
+//! destructor order is unspecified, so gcc's emutls key destructor
+//! (emutls_destroy in libgcc/emutls.c, which frees each thread_local
+//! object's storage and the per-thread array) can run before the key
+//! destructor that invokes the C++ thread_local destructors. When that
+//! happens, any thread_local object with a nontrivial destructor is
+//! destroyed after its own memory was already freed. For this ThreadContext
+//! struct that meant ~ThreadContext walking the request_threads /
+//! callback_threads std::map trees through freed memory and double-freeing
+//! their nodes, corrupting the heap.
+//!
+//! This was observed in Bitcoin Core Windows CI as intermittent
+//! STATUS_HEAP_CORRUPTION (0xC0000374) exit code 3221226356 crashes of both
+//! bitcoin-cli (its EventLoop::loop thread exiting at IPC teardown) and
+//! bitcoin-node (per-request server threads created by
+//! ProxyServer<ThreadMap>::makeThread() exiting after client disconnects) in
+//! x86_64-w64-mingw32 (msvcrt) cross builds, but not in
+//! x86_64-w64-mingw32ucrt builds — presumably pthread-key creation-order
+//! luck, since the underlying bug is CRT-independent and unsafe on all
+//! mingw-posix toolchains. Under gdb the crash appears as SIGSEGV in
+//! ~ThreadContext inside _pthread_cleanup_dest with the object memory
+//! containing the 0xfeeefeee "freed heap" debug fill pattern, matching the
+//! signature described in the upstream reports below. (Without a debugger
+//! there is no fill pattern, so the destructor walks stale-but-intact
+//! pointers and double-frees them, which is why the corruption was
+//! intermittent and often detected later, e.g. in kj::AsyncIoContext
+//! teardown, rather than at the faulting site.)
+//!
+//! Known upstream reports of this mingw-w64 bug:
+//! - https://sourceforge.net/p/mingw-w64/bugs/527/ "thread_local stl object's destructor causing crash"
+//! - https://sourceforge.net/p/mingw-w64/bugs/727/ "Crash during destruction of thread_local objects"
+//! - https://sourceforge.net/p/mingw-w64/bugs/445/ "thread_local destructors broken with posix threading"
+//! - https://sourceforge.net/p/mingw-w64/bugs/859/ "thread_local destructors not called at thread exit"
+//! - https://github.com/msys2/MINGW-packages/issues/2519 "gcc thread_local destructor cause use after free"
+//! - https://www.mail-archive.com/mingw-w64-public@lists.sourceforge.net/msg17975.html
+//!   (proposed fix discussion: "fix __cxa_thread_atexit destructors on GCC")
 ThreadContext& CurrentThread();
 
 } // namespace mp

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -40,11 +40,36 @@
 
 namespace mp {
 
-thread_local ThreadContext g_thread_context; // NOLINT(bitcoin-nontrivial-threadlocal)
-
 ThreadContext& CurrentThread()
 {
-    return g_thread_context;
+#ifdef __MINGW32__
+    // On MinGW only, deliberately leak a heap object instead of using a plain
+    // thread_local variable, because MinGW-w64's emutls implementation can
+    // free the storage backing thread_local variables before C++ destructors
+    // registered by __cxa_thread_atexit run at thread exit (pthread key
+    // destructor order is unspecified), so a nontrivial thread_local
+    // destructor can run on freed memory and corrupt the heap. Observed as
+    // intermittent STATUS_HEAP_CORRUPTION (0xC0000374) crashes in msvcrt
+    // builds. See the full explanation, gdb evidence, and mingw-w64 bug
+    // tracker links (bugs 527, 727, 445, 859, msys2 issue 2519) in the
+    // CurrentThread() declaration comment in proxy-io.h. The leaked object
+    // is held by a trivially-destructible thread_local pointer so no
+    // destructor is registered at thread exit at all.
+    //
+    // The leak is confined to MinGW because the number of IPC threads a
+    // process can create is unbounded, so leaking per-thread state on
+    // platforms with working thread_local destruction would be a real
+    // resource leak. TODO: a better long-term fix could explicitly destroy
+    // the context at the end of mp-managed thread routines (the
+    // EventLoop::loop thread, the EventLoop async thread, and
+    // ProxyServer<ThreadMap>::makeThread threads), so that even on MinGW the
+    // leak would only apply to externally-created client threads.
+    thread_local ThreadContext* context{new ThreadContext};
+    return *context;
+#else
+    thread_local ThreadContext context; // NOLINT(bitcoin-nontrivial-threadlocal)
+    return context;
+#endif
 }
 
 Stream MakeStream(EventLoop&loop, SocketId socket)


### PR DESCRIPTION
Work around mingw bug `thread_local` bug https://sourceforge.net/p/mingw-w64/bugs/527/ that causes failures in windows "test cross-built" CI jobs in https://github.com/bitcoin/bitcoin/pull/32387 by skipping `thread_local` destructors in mingw.

The workaround will result in resource leaks in mingw builds, that might be noticeable if a lot of threads are created and destroyed, but should not be a significant problem in practice.

This change is just a refactoring in other builds (including MSVC) not affected by this bug.