### PR TITLE
test: fix race in connect_tests disconnect-deferred-failure test

### DIFF
--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -139,7 +139,13 @@ KJ_TEST("ConnectStream defers disconnect failure to the first IPC request for in
     } catch (const std::runtime_error& e) {
         std::string_view reason = e.what();
 
-        KJ_EXPECT(reason == "IPC client method called after disconnect.");
+        // There is a race between the event loop detecting the disconnect
+        // and foo->add() being called. If the onDisconnect callback fires
+        // first and nulls m_context.connection, the error is "called after
+        // disconnect"; if foo->add() submits before the callback fires,
+        // the error is "interrupted by disconnect".
+        KJ_EXPECT(reason == "IPC client method called after disconnect." ||
+                  reason == "IPC client method call interrupted by disconnect.");
     }
 }
 


### PR DESCRIPTION
This fixes an intermittent `mptest` failure which is a regression from #308. Commit bb473690c97ceed78a482d6a97b480cec4a63190 introduced a test with a race condition where there the test could trigger two different exceptions depending on when the client onDisconnect handler ran, and only one of the exceptions was being checked for in the test. If the onDisconnect handler ran later, the test would fail.