### PR TITLE
test: listen_tests and connect_tests follow-ups

### DIFF
--- a/test/mp/test/common.h
+++ b/test/mp/test/common.h
@@ -1,0 +1,27 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef MP_TEST_COMMON_H
+#define MP_TEST_COMMON_H
+
+#include <kj/debug.h>
+#include <mp/proxy-io.h>
+
+#include <stdexcept>
+
+namespace mp {
+namespace test {
+
+//! Default event loop log handler used by tests. Logs all messages and throws
+//! on errors so calling code can assert on them.
+inline void DefaultLogHandler(LogMessage log)
+{
+    KJ_LOG(INFO, log.level, log.message);
+    if (log.level == Log::Raise) throw std::runtime_error(log.message);
+}
+
+} // namespace test
+} // namespace mp
+
+#endif // MP_TEST_COMMON_H

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -79,7 +79,6 @@ KJ_TEST("ConnectStream connects to a socket serving a valid init interface")
 
     init.reset();
     server_thread.join();
-    KJ_EXPECT(true);
 }
 
 KJ_TEST("ConnectStream throws when the socket is already disconnected")

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -166,14 +166,12 @@ KJ_TEST("ConnectStream throws when the socket disconnects after receiving data")
     try {
         auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
-        if (server_thread.joinable()) server_thread.join();
         KJ_EXPECT(false);
     } catch (const std::runtime_error& e) {
-        if (server_thread.joinable()) server_thread.join();
-
         std::string_view reason = e.what();
         KJ_EXPECT(reason == "IPC client method call interrupted by disconnect.");
     }
+    server_thread.join();
 }
 
 KJ_TEST("ConnectStream throws when a connection accepted from a listener disconnects after receiving data")
@@ -202,14 +200,12 @@ KJ_TEST("ConnectStream throws when a connection accepted from a listener disconn
     try {
         auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
-        if (server_thread.joinable()) server_thread.join();
         KJ_EXPECT(false);
     } catch (const std::runtime_error& e) {
-        if (server_thread.joinable()) server_thread.join();
-
         std::string_view reason = e.what();
         KJ_EXPECT(reason == "IPC client method call interrupted by disconnect.");
     }
+    server_thread.join();
 }
 
 } // namespace

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -7,18 +7,18 @@
 #include <kj/debug.h>
 #include <kj/memory.h>
 #include <kj/test.h>
-#include <mp/proxy.h>
 #include <mp/proxy-io.h>
+#include <mp/proxy.h>
 #include <mp/test/foo.capnp.h>
 #include <mp/test/foo.capnp.proxy.h>
+#include <mp/util.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 
+#include <array>
 #include <chrono>
 #include <condition_variable>
 #include <cstring> // IWYU pragma: keep
-#include <functional>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -45,9 +45,6 @@ void DefaultLogHandler(mp::LogMessage log)
 class TestSetup
 {
 public:
-    int m_client_fd;
-    int m_server_fd;
-
     mp::EventLoop* m_loop;
     std::optional<mp::EventLoopRef> m_loop_ref;
     //! Thread variable should be after other struct members so the thread does
@@ -55,14 +52,6 @@ public:
     std::thread m_loop_thread;
 
     TestSetup(mp::LogFn log_handler = DefaultLogHandler)
-        : TestSetup(
-              [](int fds[2]) {
-                  KJ_REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != -1);
-              },
-              log_handler) {}
-
-    TestSetup(const std::function<void(int[2])>& init_sockets,
-              mp::LogFn log_handler = DefaultLogHandler)
     {
         std::promise<mp::EventLoop*> loop_promise;
         m_loop_thread = std::thread([&, log_handler] {
@@ -72,13 +61,6 @@ public:
         });
         m_loop = loop_promise.get_future().get();
         m_loop_ref.emplace(*m_loop);
-
-        // Initialize and store sockets
-        int fds[2] = {-1, -1};
-        init_sockets(fds);
-
-        m_client_fd = fds[0];
-        m_server_fd = fds[1];
     }
 
     ~TestSetup()
@@ -91,15 +73,16 @@ public:
 KJ_TEST("ConnectStream connects to a socket serving a valid init interface")
 {
     TestSetup setup;
+    auto [client_fd, server_fd] = SocketPair();
 
-    std::thread server_thread([&setup]() {
+    std::thread server_thread([&]() {
         mp::EventLoop server_loop("mptest-valid-server", DefaultLogHandler);
         std::unique_ptr<FooInit> init = std::make_unique<FooInit>();
-        ServeStream<messages::FooInit>(server_loop, MakeStream(server_loop, setup.m_server_fd), *init);
+        ServeStream<messages::FooInit>(server_loop, MakeStream(server_loop, server_fd), *init);
         server_loop.loop();
     });
 
-    auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
+    auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
     init.reset();
     server_thread.join();
@@ -109,11 +92,12 @@ KJ_TEST("ConnectStream connects to a socket serving a valid init interface")
 KJ_TEST("ConnectStream throws when the socket is already disconnected")
 {
     TestSetup setup;
+    auto [client_fd, server_fd] = SocketPair();
 
-    close(setup.m_server_fd);
+    close(server_fd);
 
     try {
-        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
+        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
         KJ_EXPECT(false);
     } catch (const std::runtime_error& e) {
@@ -126,12 +110,13 @@ KJ_TEST("ConnectStream throws when the socket is already disconnected")
 KJ_TEST("ConnectStream defers disconnect failure to the first IPC request for interfaces without construct()")
 {
     TestSetup setup;
+    auto [client_fd, server_fd] = SocketPair();
 
-    close(setup.m_server_fd);
+    close(server_fd);
 
     // Without a construct() method no IPC call is made during client
     // creation, so ConnectStream succeeds even though the peer is gone.
-    auto foo = ConnectStream<messages::FooInterface>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
+    auto foo = ConnectStream<messages::FooInterface>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
     try {
         foo->add(1, 2);
@@ -157,10 +142,11 @@ KJ_TEST("ConnectStream handles a disconnect when no client calls are made")
         }
         DefaultLogHandler(log);
     });
+    auto [client_fd, server_fd] = SocketPair();
 
-    close(setup.m_server_fd);
+    close(server_fd);
 
-    auto foo = ConnectStream<messages::FooInterface>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
+    auto foo = ConnectStream<messages::FooInterface>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
     // The disconnect handler registered by ProxyClientBase should run and
     // delete the connection even when no calls are ever made.
@@ -171,20 +157,21 @@ KJ_TEST("ConnectStream handles a disconnect when no client calls are made")
 KJ_TEST("ConnectStream throws when the socket disconnects after receiving data")
 {
     TestSetup setup;
+    auto [client_fd, server_fd] = SocketPair();
 
-    std::thread server_thread([&setup]() {
+    std::thread server_thread([&]() {
         char buf[128];
 
         ssize_t bytes_received =
-            recv(setup.m_server_fd, buf, sizeof(buf), 0);
+            recv(server_fd, buf, sizeof(buf), 0);
 
         if (bytes_received > 0) {
-            close(setup.m_server_fd);
+            close(server_fd);
         }
     });
 
     try {
-        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
+        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
         if (server_thread.joinable()) server_thread.join();
         KJ_EXPECT(false);
@@ -199,16 +186,14 @@ KJ_TEST("ConnectStream throws when the socket disconnects after receiving data")
 KJ_TEST("ConnectStream throws when a connection accepted from a listener disconnects after receiving data")
 {
     UnixListener listener;
+    TestSetup setup;
+    int client_fd = listener.MakeConnectedSocket();
+    int server_fd = listener.release();
 
-    TestSetup setup([&listener](int fds[2]) {
-        fds[0] = listener.MakeConnectedSocket(); // client_fd
-        fds[1] = listener.release();             // server_fd
-    });
-
-    std::thread server_thread([&setup]() {
+    std::thread server_thread([&]() {
         char buf[128];
 
-        int connection_fd = accept(setup.m_server_fd, nullptr, nullptr);
+        int connection_fd = accept(server_fd, nullptr, nullptr);
 
         if (connection_fd >= 0) {
             ssize_t bytes_received =
@@ -218,11 +203,11 @@ KJ_TEST("ConnectStream throws when a connection accepted from a listener disconn
                 close(connection_fd);
             }
         }
-        close(setup.m_server_fd);
+        close(server_fd);
     });
 
     try {
-        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
+        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
         if (server_thread.joinable()) server_thread.join();
         KJ_EXPECT(false);

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -75,6 +75,8 @@ KJ_TEST("ConnectStream connects to a socket serving a valid init interface")
         server_loop.loop();
     });
 
+    // FooInit has a `construct()` method, so this connects to the server and
+    // sends an IPC request that must complete successfully.
     auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
     init.reset();

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -45,14 +45,14 @@ void DefaultLogHandler(mp::LogMessage log)
 class TestSetup
 {
 public:
-    int client_fd;
-    int server_fd;
+    int m_client_fd;
+    int m_server_fd;
 
-    mp::EventLoop* loop;
-    std::optional<mp::EventLoopRef> loop_ref;
+    mp::EventLoop* m_loop;
+    std::optional<mp::EventLoopRef> m_loop_ref;
     //! Thread variable should be after other struct members so the thread does
     //! not start until the other members are initialized.
-    std::thread loop_thread;
+    std::thread m_loop_thread;
 
     TestSetup(mp::LogFn log_handler = DefaultLogHandler)
         : TestSetup(
@@ -65,26 +65,26 @@ public:
               mp::LogFn log_handler = DefaultLogHandler)
     {
         std::promise<mp::EventLoop*> loop_promise;
-        loop_thread = std::thread([&, log_handler] {
+        m_loop_thread = std::thread([&, log_handler] {
             mp::EventLoop loop("mptest-connect", log_handler);
             loop_promise.set_value(&loop);
             loop.loop();
         });
-        loop = loop_promise.get_future().get();
-        loop_ref.emplace(*loop);
+        m_loop = loop_promise.get_future().get();
+        m_loop_ref.emplace(*m_loop);
 
         // Initialize and store sockets
         int fds[2] = {-1, -1};
         init_sockets(fds);
 
-        client_fd = fds[0];
-        server_fd = fds[1];
+        m_client_fd = fds[0];
+        m_server_fd = fds[1];
     }
 
     ~TestSetup()
     {
-        loop_ref.reset();
-        loop_thread.join();
+        m_loop_ref.reset();
+        m_loop_thread.join();
     }
 };
 
@@ -95,11 +95,11 @@ KJ_TEST("ConnectStream connects to a socket serving a valid init interface")
     std::thread server_thread([&setup]() {
         mp::EventLoop server_loop("mptest-valid-server", DefaultLogHandler);
         std::unique_ptr<FooInit> init = std::make_unique<FooInit>();
-        ServeStream<messages::FooInit>(server_loop, MakeStream(server_loop, setup.server_fd), *init);
+        ServeStream<messages::FooInit>(server_loop, MakeStream(server_loop, setup.m_server_fd), *init);
         server_loop.loop();
     });
 
-    auto init = ConnectStream<messages::FooInit>(*setup.loop, MakeStream(*setup.loop, setup.client_fd));
+    auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
 
     init.reset();
     server_thread.join();
@@ -110,10 +110,10 @@ KJ_TEST("ConnectStream throws when the socket is already disconnected")
 {
     TestSetup setup;
 
-    close(setup.server_fd);
+    close(setup.m_server_fd);
 
     try {
-        auto init = ConnectStream<messages::FooInit>(*setup.loop, MakeStream(*setup.loop, setup.client_fd));
+        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
 
         KJ_EXPECT(false);
     } catch (const std::runtime_error& e) {
@@ -127,11 +127,11 @@ KJ_TEST("ConnectStream defers disconnect failure to the first IPC request for in
 {
     TestSetup setup;
 
-    close(setup.server_fd);
+    close(setup.m_server_fd);
 
     // Without a construct() method no IPC call is made during client
     // creation, so ConnectStream succeeds even though the peer is gone.
-    auto foo = ConnectStream<messages::FooInterface>(*setup.loop, MakeStream(*setup.loop, setup.client_fd));
+    auto foo = ConnectStream<messages::FooInterface>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
 
     try {
         foo->add(1, 2);
@@ -158,9 +158,9 @@ KJ_TEST("ConnectStream handles a disconnect when no client calls are made")
         DefaultLogHandler(log);
     });
 
-    close(setup.server_fd);
+    close(setup.m_server_fd);
 
-    auto foo = ConnectStream<messages::FooInterface>(*setup.loop, MakeStream(*setup.loop, setup.client_fd));
+    auto foo = ConnectStream<messages::FooInterface>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
 
     // The disconnect handler registered by ProxyClientBase should run and
     // delete the connection even when no calls are ever made.
@@ -176,15 +176,15 @@ KJ_TEST("ConnectStream throws when the socket disconnects after receiving data")
         char buf[128];
 
         ssize_t bytes_received =
-            recv(setup.server_fd, buf, sizeof(buf), 0);
+            recv(setup.m_server_fd, buf, sizeof(buf), 0);
 
         if (bytes_received > 0) {
-            close(setup.server_fd);
+            close(setup.m_server_fd);
         }
     });
 
     try {
-        auto init = ConnectStream<messages::FooInit>(*setup.loop, MakeStream(*setup.loop, setup.client_fd));
+        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
 
         if (server_thread.joinable()) server_thread.join();
         KJ_EXPECT(false);
@@ -208,7 +208,7 @@ KJ_TEST("ConnectStream throws when a connection accepted from a listener disconn
     std::thread server_thread([&setup]() {
         char buf[128];
 
-        int connection_fd = accept(setup.server_fd, nullptr, nullptr);
+        int connection_fd = accept(setup.m_server_fd, nullptr, nullptr);
 
         if (connection_fd >= 0) {
             ssize_t bytes_received =
@@ -218,11 +218,11 @@ KJ_TEST("ConnectStream throws when a connection accepted from a listener disconn
                 close(connection_fd);
             }
         }
-        close(setup.server_fd);
+        close(setup.m_server_fd);
     });
 
     try {
-        auto init = ConnectStream<messages::FooInit>(*setup.loop, MakeStream(*setup.loop, setup.client_fd));
+        auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, setup.m_client_fd));
 
         if (server_thread.joinable()) server_thread.join();
         KJ_EXPECT(false);

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -86,7 +86,7 @@ KJ_TEST("ConnectStream throws when the socket is already disconnected")
     TestSetup setup;
     auto [client_fd, server_fd] = SocketPair();
 
-    close(server_fd);
+    KJ_SYSCALL(close(server_fd));
 
     try {
         auto init = ConnectStream<messages::FooInit>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
@@ -104,7 +104,7 @@ KJ_TEST("ConnectStream defers disconnect failure to the first IPC request for in
     TestSetup setup;
     auto [client_fd, server_fd] = SocketPair();
 
-    close(server_fd);
+    KJ_SYSCALL(close(server_fd));
 
     // Without a construct() method no IPC call is made during client
     // creation, so ConnectStream succeeds even though the peer is gone.
@@ -136,7 +136,7 @@ KJ_TEST("ConnectStream handles a disconnect when no client calls are made")
     });
     auto [client_fd, server_fd] = SocketPair();
 
-    close(server_fd);
+    KJ_SYSCALL(close(server_fd));
 
     auto foo = ConnectStream<messages::FooInterface>(*setup.m_loop, MakeStream(*setup.m_loop, client_fd));
 
@@ -154,12 +154,8 @@ KJ_TEST("ConnectStream throws when the socket disconnects after receiving data")
     std::thread server_thread([&]() {
         char buf[128];
 
-        ssize_t bytes_received =
-            recv(server_fd, buf, sizeof(buf), 0);
-
-        if (bytes_received > 0) {
-            close(server_fd);
-        }
+        recv(server_fd, buf, sizeof(buf), 0);
+        KJ_SYSCALL(close(server_fd));
     });
 
     try {
@@ -186,14 +182,10 @@ KJ_TEST("ConnectStream throws when a connection accepted from a listener disconn
         int connection_fd = accept(server_fd, nullptr, nullptr);
 
         if (connection_fd >= 0) {
-            ssize_t bytes_received =
-                recv(connection_fd, buf, sizeof(buf), 0);
-
-            if (bytes_received > 0) {
-                close(connection_fd);
-            }
+            recv(connection_fd, buf, sizeof(buf), 0);
+            KJ_SYSCALL(close(connection_fd));
         }
-        close(server_fd);
+        KJ_SYSCALL(close(server_fd));
     });
 
     try {

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -38,17 +38,17 @@ constexpr auto FAILURE_TIMEOUT = std::chrono::seconds{30};
 class TestSetup
 {
 public:
-    mp::EventLoop* m_loop;
-    std::optional<mp::EventLoopRef> m_loop_ref;
+    EventLoop* m_loop;
+    std::optional<EventLoopRef> m_loop_ref;
     //! Thread variable should be after other struct members so the thread does
     //! not start until the other members are initialized.
     std::thread m_loop_thread;
 
-    TestSetup(mp::LogFn log_handler = DefaultLogHandler)
+    TestSetup(LogFn log_handler = DefaultLogHandler)
     {
-        std::promise<mp::EventLoop*> loop_promise;
+        std::promise<EventLoop*> loop_promise;
         m_loop_thread = std::thread([&, log_handler] {
-            mp::EventLoop loop("mptest-connect", log_handler);
+            EventLoop loop("mptest-connect", log_handler);
             loop_promise.set_value(&loop);
             loop.loop();
         });
@@ -69,7 +69,7 @@ KJ_TEST("ConnectStream connects to a socket serving a valid init interface")
     auto [client_fd, server_fd] = SocketPair();
 
     std::thread server_thread([&]() {
-        mp::EventLoop server_loop("mptest-valid-server", DefaultLogHandler);
+        EventLoop server_loop("mptest-valid-server", DefaultLogHandler);
         std::unique_ptr<FooInit> init = std::make_unique<FooInit>();
         ServeStream<messages::FooInit>(server_loop, MakeStream(server_loop, server_fd), *init);
         server_loop.loop();
@@ -127,8 +127,8 @@ KJ_TEST("ConnectStream handles a disconnect when no client calls are made")
     std::condition_variable cv;
     bool warned = false;
 
-    TestSetup setup([&](mp::LogMessage log) {
-        if (log.level == mp::Log::Warning && log.message.find("unexpected network disconnect") != std::string::npos) {
+    TestSetup setup([&](LogMessage log) {
+        if (log.level == Log::Warning && log.message.find("unexpected network disconnect") != std::string::npos) {
             const std::lock_guard<std::mutex> lock(mutex);
             warned = true;
             cv.notify_all();

--- a/test/mp/test/connect_tests.cpp
+++ b/test/mp/test/connect_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "common.h"
 #include "unixlistener.h"
 #include <kj/async.h>
 #include <kj/common.h>
@@ -33,14 +34,6 @@ namespace test {
 namespace {
 
 constexpr auto FAILURE_TIMEOUT = std::chrono::seconds{30};
-
-//! Default event loop log handler used by tests, throws so the calling code
-//! can assert on errors.
-void DefaultLogHandler(mp::LogMessage log)
-{
-    if (log.level == mp::Log::Raise)
-        throw std::runtime_error(log.message);
-}
 
 class TestSetup
 {

--- a/test/mp/test/listen_tests.cpp
+++ b/test/mp/test/listen_tests.cpp
@@ -241,7 +241,7 @@ KJ_TEST("ListenConnections handles a client that disconnects before being accept
         // The event loop then reports this as an uncaught task exception. We catch and ignore
         // this specific error here so that the corresponding CI job does not fail.
         //
-        // This is a Cap'n Proto bug, a fix is available in the v2 branch at: https://github.com/capnproto/capnproto/commit/7df5bd078f389ded313479981bd0ae06cbcdfe1b#diff-ec577ad66535f58f6d7396ea51d3e56c0065308aa8fb02751cd6a8cfaa67252fR1358-R1372
+        // This is a Cap'n Proto bug, fixed by https://github.com/capnproto/capnproto/pull/2748
         if (log.level == mp::Log::Error && log.message.find("Uncaught exception in daemonized task.") != std::string::npos) {
             Lock lock(mutex);
             accept_error = true;

--- a/test/mp/test/listen_tests.cpp
+++ b/test/mp/test/listen_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "common.h"
 #include "unixlistener.h"
 #include <mp/test/foo.capnp.h>
 #include <mp/test/foo.capnp.proxy.h>
@@ -23,7 +24,6 @@
 #include <mp/util.h>
 #include <ratio> // IWYU pragma: keep
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <unistd.h>
@@ -42,10 +42,7 @@ class ClientSetup
 public:
     explicit ClientSetup(int fd)
         : thread([this, fd] {
-              EventLoop loop("mptest-client", [](mp::LogMessage log) {
-                  KJ_LOG(INFO, log.level, log.message);
-                  if (log.level == mp::Log::Raise) throw std::runtime_error(log.message);
-              });
+              EventLoop loop("mptest-client", DefaultLogHandler);
               client_promise.set_value(ConnectStream<messages::FooInterface>(loop, MakeStream(loop, fd)));
               loop.loop();
           })
@@ -66,13 +63,6 @@ public:
     //! not start until the other members are initialized.
     std::thread thread;
 };
-
-//! Default server event loop log handler, throws so tests can assert on errors.
-void DefaultLogHandler(mp::LogMessage log)
-{
-    KJ_LOG(INFO, log.level, log.message);
-    if (log.level == mp::Log::Raise) throw std::runtime_error(log.message);
-}
 
 //! Runs a server EventLoop on its own thread, starts ListenConnections() on a
 //! UnixListener socket, and records connection/disconnection counts through


### PR DESCRIPTION
Addresses review suggestions left (all of them made by ryanofsky) in the now-merged PRs #298 and #310.

These are non-critical test cleanups (naming, simplification, comments, etc.) with zero changes to library code.