### PR TITLE
Remove trailing whitespace and Add -Wtrailing-whitespace to default ci config

### DIFF
--- a/ci/configs/default.bash
+++ b/ci/configs/default.bash
@@ -1,5 +1,5 @@
 CI_DESC="CI job using default libraries and tools, and running IWYU"
 CI_DIR=build-default
-export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wextra-semi -Wmissing-noreturn"
+export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wextra-semi -Wmissing-noreturn -Wtrailing-whitespace"
 CMAKE_ARGS=(-DMP_ENABLE_IWYU=ON)
 BUILD_ARGS=(-k)

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -166,7 +166,7 @@ void WriteSpawnError(int fd, const SpawnError& error)
 
 // Get rid of a child process the parent is abandoning because SpawnProcess is
 // about to throw, so it is not left behind as a zombie. The child may still be
-// alive, so kill it first: waiting without that could block for as long as the 
+// alive, so kill it first: waiting without that could block for as long as the
 // spawned program runs.
 void KillAndReapChild(ProcessId pid)
 {


### PR DESCRIPTION
Removes trailing whitespace that [breaks](https://github.com/bitcoin/bitcoin/actions/runs/31830711816/job/94865454299?pr=10102#step:11:1263) the upstream Bitcoin Core build, and enables the warning on the ci here so it does not recur.