### PR TITLE
refactor: Replace EventLoop::post() with sync() taking kj::FunctionParam

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -301,7 +301,7 @@ public:
     std::thread m_async_thread;
 
     //! Callback function to run on event loop thread during sync() call.
-    kj::FunctionParam<void()>* m_post_fn MP_GUARDED_BY(m_mutex) = nullptr;
+    kj::FunctionParam<void()>* m_sync_fn MP_GUARDED_BY(m_mutex) = nullptr;
 
     //! Callback functions to run on async thread.
     std::optional<CleanupList> m_async_fns MP_GUARDED_BY(m_mutex);

--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -233,8 +233,8 @@ Stream MakeStream(EventLoop&loop, SocketId socket);
 //! assumes it will only be accessed from one thread. So all this code needs to
 //! actually run on one thread, and the EventLoop::loop() method is the entry point for
 //! this thread. ProxyClient and ProxyServer objects that use other threads and
-//! need to perform I/O operations post to this thread using EventLoop::post()
-//! and EventLoop::sync() methods.
+//! need to perform I/O operations post to this thread using the
+//! EventLoop::sync() method.
 //!
 //! Specifically, because ProxyClient methods can be called from arbitrary
 //! threads, and ProxyServer methods can run on arbitrary threads, ProxyClient
@@ -267,16 +267,7 @@ public:
 
     //! Run function on event loop thread. Does not return until function completes.
     //! Must be called while the loop() function is active.
-    void post(kj::Function<void()> fn);
-
-    //! Wrapper around EventLoop::post that takes advantage of the
-    //! fact that callable will not go out of scope to avoid requirement that it
-    //! be copyable.
-    template <typename Callable>
-    void sync(Callable&& callable)
-    {
-        post(std::forward<Callable>(callable));
-    }
+    void sync(kj::FunctionParam<void()> fn);
 
     //! Register cleanup function to run on asynchronous worker thread without
     //! blocking the event loop thread.
@@ -309,8 +300,8 @@ public:
     //! method has not been called.
     std::thread m_async_thread;
 
-    //! Callback function to run on event loop thread during post() or sync() call.
-    kj::Function<void()>* m_post_fn MP_GUARDED_BY(m_mutex) = nullptr;
+    //! Callback function to run on event loop thread during sync() call.
+    kj::FunctionParam<void()>* m_post_fn MP_GUARDED_BY(m_mutex) = nullptr;
 
     //! Callback functions to run on async thread.
     std::optional<CleanupList> m_async_fns MP_GUARDED_BY(m_mutex);

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -306,7 +306,7 @@ void EventLoop::loop()
         Lock lock(m_mutex);
         if (m_post_fn) {
             // m_post_fn throwing is never expected. If it does happen, the caller
-            // of EventLoop::post() will return without any indication of failure,
+            // of EventLoop::sync() will return without any indication of failure,
             // which will likely cause other bugs. Log the error and continue.
             KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() MP_REQUIRES(m_mutex) { Unlock(lock, *m_post_fn); })) {
                 MP_LOG(*this, Log::Error) << "EventLoop: m_post_fn threw: " << kj::str(*exception).cStr();
@@ -315,7 +315,7 @@ void EventLoop::loop()
             m_cv.notify_all();
         } else if (done()) {
             // Intentionally do not break if m_post_fn was set, even if done()
-            // would return true, to ensure that the post() m_post_writer->write()
+            // would return true, to ensure that the sync() m_post_writer->write()
             // call always succeeds and the loop does not exit between the time
             // that the done condition is set and the write call is made.
             break;
@@ -333,7 +333,7 @@ void EventLoop::loop()
     m_cv.notify_all();
 }
 
-void EventLoop::post(kj::Function<void()> fn)
+void EventLoop::sync(kj::FunctionParam<void()> fn)
 {
     if (std::this_thread::get_id() == m_thread_id) {
         fn();

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -275,7 +275,7 @@ EventLoop::~EventLoop()
 {
     if (m_async_thread.joinable()) m_async_thread.join();
     const Lock lock(m_mutex);
-    KJ_ASSERT(m_post_fn == nullptr);
+    KJ_ASSERT(m_sync_fn == nullptr);
     KJ_ASSERT(!m_async_fns);
     KJ_ASSERT(!m_wait_stream);
     KJ_ASSERT(!m_post_stream);
@@ -304,17 +304,17 @@ void EventLoop::loop()
         const size_t read_bytes = wait_stream->read(&buffer, 0, 1).wait(m_io_context.waitScope);
         if (read_bytes != 1) throw std::logic_error("EventLoop wait_stream closed unexpectedly");
         Lock lock(m_mutex);
-        if (m_post_fn) {
-            // m_post_fn throwing is never expected. If it does happen, the caller
+        if (m_sync_fn) {
+            // m_sync_fn throwing is never expected. If it does happen, the caller
             // of EventLoop::sync() will return without any indication of failure,
             // which will likely cause other bugs. Log the error and continue.
-            KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() MP_REQUIRES(m_mutex) { Unlock(lock, *m_post_fn); })) {
-                MP_LOG(*this, Log::Error) << "EventLoop: m_post_fn threw: " << kj::str(*exception).cStr();
+            KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() MP_REQUIRES(m_mutex) { Unlock(lock, *m_sync_fn); })) {
+                MP_LOG(*this, Log::Error) << "EventLoop: m_sync_fn threw: " << kj::str(*exception).cStr();
             }
-            m_post_fn = nullptr;
+            m_sync_fn = nullptr;
             m_cv.notify_all();
         } else if (done()) {
-            // Intentionally do not break if m_post_fn was set, even if done()
+            // Intentionally do not break if m_sync_fn was set, even if done()
             // would return true, to ensure that the sync() m_post_writer->write()
             // call always succeeds and the loop does not exit between the time
             // that the done condition is set and the write call is made.
@@ -341,13 +341,13 @@ void EventLoop::sync(kj::FunctionParam<void()> fn)
     }
     Lock lock(m_mutex);
     EventLoopRef ref(*this, &lock);
-    m_cv.wait(lock.m_lock, [this]() MP_REQUIRES(m_mutex) { return m_post_fn == nullptr; });
-    m_post_fn = &fn;
+    m_cv.wait(lock.m_lock, [this]() MP_REQUIRES(m_mutex) { return m_sync_fn == nullptr; });
+    m_sync_fn = &fn;
     Unlock(lock, [&] {
         char buffer = 0;
         m_post_writer->write(&buffer, 1);
     });
-    m_cv.wait(lock.m_lock, [this, &fn]() MP_REQUIRES(m_mutex) { return m_post_fn != &fn; });
+    m_cv.wait(lock.m_lock, [this, &fn]() MP_REQUIRES(m_mutex) { return m_sync_fn != &fn; });
 }
 
 void EventLoop::startAsyncThread()

--- a/test/mp/test/listen_tests.cpp
+++ b/test/mp/test/listen_tests.cpp
@@ -16,6 +16,7 @@
 #include <kj/async.h>
 #include <kj/common.h>
 #include <kj/debug.h>
+#include <kj/function.h>
 #include <kj/memory.h>
 #include <kj/test.h>
 #include <memory>

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -20,6 +20,7 @@
 #include <kj/common.h>
 #include <kj/exception.h>
 #include <kj/debug.h>
+#include <kj/function.h>
 #include <kj/memory.h>
 #include <kj/string.h>
 #include <kj/test.h>


### PR DESCRIPTION
EventLoop::post() and the sync() wrapper around it did the same thing, so this merges them into a single sync() method. And also takes the callback as a [kj::FunctionParam](https://github.com/capnproto/capnproto/blob/v1.5.0/c%2B%2B/src/kj/function.h#L91) instead of a kj::Function: FunctionParam stores only a pointer to the caller's callable rather than taking ownership of it, so the callable no longer needs to be copyable or movable, and each call avoids a heap allocation.

This is safe because sync() does not return until the event loop thread has finished running the callback and cleared m_post_fn(now named m_sync_fn), so the pointer is never used after the callable goes out of scope.