### PR TITLE
cmake: add type-unordered-set.h and version.h to public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,11 @@ set(MP_PUBLIC_HEADERS
   include/mp/type-struct.h
   include/mp/type-threadmap.h
   include/mp/type-tuple.h
+  include/mp/type-unordered-set.h
   include/mp/type-vector.h
   include/mp/type-void.h
-  include/mp/util.h)
+  include/mp/util.h
+  include/mp/version.h)
 add_library(multiprocess STATIC
   ${MP_PROXY_SRCS}
   ${MP_PUBLIC_HEADERS}


### PR DESCRIPTION
These are useful for building bitcoin core with WITH_EXTERNAL_LIBMULTIPROCESS and having the install target install the complete set of public headers more generally.