### PR TITLE
ci: do not ignore NIXPKGS_CHANNEL in local ci runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,10 @@ jobs:
 
     env:
       CI_NIXPKGS_CHANNEL: nixos-26.05
-      NIX_EXTRA_CONFIG: |
+      CI_NIX_CONFIG: |
         keep-env-derivations = true
         keep-outputs = true
-      NIX_EXTRA_CONFIG_ACT: |
+      CI_NIX_CONFIG_ACT: |
         sandbox = false
         filter-syscalls = false
 
@@ -168,8 +168,8 @@ jobs:
           # so KVM support isn't available.
           enable_kvm: "${{ github.actor != 'nektos/act' }}"
           extra_nix_config: |
-            ${{ env.NIX_EXTRA_CONFIG }}
-            ${{ github.actor == 'nektos/act' && env.NIX_EXTRA_CONFIG_ACT || '' }}
+            ${{ env.CI_NIX_CONFIG }}
+            ${{ github.actor == 'nektos/act' && env.CI_NIX_CONFIG_ACT || '' }}
 
       - name: Cache Nix store
         if: steps.config.outputs.cache_nix_store == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NIXPKGS_CHANNEL: nixos-26.05
+      CI_NIXPKGS_CHANNEL: nixos-26.05
       NIX_EXTRA_CONFIG: |
         keep-env-derivations = true
         keep-outputs = true
@@ -164,7 +164,6 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31       # 2025-05-27, from https://github.com/cachix/install-nix-action/tags
         with:
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ steps.config.outputs.nixpkgs_rev }}.tar.gz
           # Act executes inside an unprivileged container (Docker or Podman),
           # so KVM support isn't available.
           enable_kvm: "${{ github.actor != 'nektos/act' }}"

--- a/ci/configs/olddeps.bash
+++ b/ci/configs/olddeps.bash
@@ -2,7 +2,7 @@ CI_DESC="CI job using old Cap'n Proto and cmake versions"
 CI_DIR=build-olddeps
 # Pin olddeps to an older Nixpkgs channel, since compiling the old CMake
 # requires an older GCC.
-NIXPKGS_CHANNEL=nixos-25.05
+CI_NIXPKGS_CHANNEL=nixos-25.05
 export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
 NIX_ARGS=(--argstr capnprotoVersion "0.9.2" --argstr cmakeVersion "3.12.4" --argstr gccVersion "11")
 BUILD_ARGS=(-k)

--- a/ci/scripts/config.sh
+++ b/ci/scripts/config.sh
@@ -17,8 +17,8 @@ source "${SCRIPT_DIR}/ci_helpers.sh"
 [ "${CI_CONFIG+x}" ] && source "$CI_CONFIG"
 
 # Resolve the nixpkgs channel to a specific revision for use in cache keys.
-if [[ -n "${NIXPKGS_CHANNEL:-}" ]]; then
-  rev="$(curl --fail --location --silent --show-error "https://channels.nixos.org/${NIXPKGS_CHANNEL}/git-revision")"
+if [[ -n "${CI_NIXPKGS_CHANNEL:-}" ]]; then
+  rev="$(curl --fail --location --silent --show-error "https://channels.nixos.org/${CI_NIXPKGS_CHANNEL}/git-revision")"
   test -n "${rev}"
   write_output_var nixpkgs_rev "${rev}"
 fi

--- a/ci/scripts/run.sh
+++ b/ci/scripts/run.sh
@@ -10,14 +10,16 @@ set -o errexit -o nounset -o pipefail -o xtrace
 
 [ "${CI_CONFIG+x}" ] && source "$CI_CONFIG"
 
-nix develop --ignore-environment --keep CI_CONFIG --keep CI_CLEAN "${NIX_ARGS[@]+"${NIX_ARGS[@]}"}" -f shell.nix --command ci/scripts/ci.sh
+nix_args=("${NIX_ARGS[@]+${NIX_ARGS[@]}}")
+if [[ -n "${CI_NIXPKGS_CHANNEL:-}" ]]; then
+  nix_args+=(-I "nixpkgs=channel:${CI_NIXPKGS_CHANNEL}")
+fi
+nix develop "${nix_args[@]}" --ignore-environment --keep CI_CONFIG --keep CI_CLEAN -f shell.nix --command ci/scripts/ci.sh
 
 # Create a GC root for the shell closure so the cache-nix-action save step
 # does not garbage-collect it.
 if [ -n "${CI_CACHE_NIX_STORE-}" ]; then
-  nix-build shell.nix \
-    -o "$CI_DIR/gcroot" \
-    "${NIX_ARGS[@]+"${NIX_ARGS[@]}"}"
+  nix-build shell.nix "${nix_args[@]}" -o "$CI_DIR/gcroot"
   # Verify the closure is complete so the cache-nix-action save step has
   # everything it needs.
   nix-store --query --requisites "$CI_DIR/gcroot" >/dev/null


### PR DESCRIPTION
Currently, the `olddeps` ci job specifies nixos-25.05 channel, but this is ignored in local ci runs, because the channel is set in `.github/workflows/ci.yml` not `ci/scripts/run.sh`.

Fix this and also rename CI environment variables to consistently use `CI_` prefix