### PR TITLE
cmake: make Threads package optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,13 @@ endif()
 
 include("cmake/compat_find.cmake")
 
-find_package(Threads REQUIRED)
+add_library(mpdeps INTERFACE)
+
+find_package(Threads)
+if(Threads_FOUND)
+  target_link_libraries(mpdeps INTERFACE Threads::Threads)
+endif()
+
 find_package(CapnProto 0.9 NO_MODULE)
  if(NOT CapnProto_FOUND)
    message(FATAL_ERROR
@@ -206,7 +212,7 @@ target_link_libraries(mpgen PRIVATE CapnProto::capnp)
 target_link_libraries(mpgen PRIVATE CapnProto::capnpc)
 target_link_libraries(mpgen PRIVATE CapnProto::kj)
 target_link_libraries(mpgen PRIVATE CapnProto::kj-async)
-target_link_libraries(mpgen PRIVATE Threads::Threads)
+target_link_libraries(mpgen PRIVATE mpdeps)
 # Use CAPNP_EXECUTABLE/CAPNPC_CXX_EXECUTABLE cmake variables set by
 # CapnProtoConfig.cmake rather than reading the CapnProto::capnp_tool
 # IMPORTED_LOCATION directly. On Debian/Ubuntu, IMPORTED_LOCATION is broken

--- a/cmake/pthread_checks.cmake
+++ b/cmake/pthread_checks.cmake
@@ -9,7 +9,9 @@ include(CMakePushCheckState)
 include(CheckCXXSourceCompiles)
 
 cmake_push_check_state()
-set(CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+if(TARGET Threads::Threads)
+  set(CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+endif()
 check_cxx_source_compiles("
   #include <pthread.h>
   int main(int argc, char** argv)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,20 +9,20 @@ add_executable(mpcalculator
 )
 target_capnp_sources(mpcalculator ${CMAKE_CURRENT_SOURCE_DIR} init.capnp calculator.capnp printer.capnp)
 target_include_directories(mpcalculator PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(mpcalculator PRIVATE Threads::Threads)
+target_link_libraries(mpcalculator PRIVATE mpdeps)
 
 add_executable(mpprinter
   printer.cpp
 )
 target_capnp_sources(mpprinter ${CMAKE_CURRENT_SOURCE_DIR} init.capnp calculator.capnp printer.capnp)
 target_include_directories(mpprinter PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(mpprinter PRIVATE Threads::Threads)
+target_link_libraries(mpprinter PRIVATE mpdeps)
 
 add_executable(mpexample
   example.cpp
 )
 target_capnp_sources(mpexample ${CMAKE_CURRENT_SOURCE_DIR} init.capnp calculator.capnp printer.capnp)
 target_include_directories(mpexample PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(mpexample PRIVATE Threads::Threads)
+target_link_libraries(mpexample PRIVATE mpdeps)
 
 add_custom_target(mpexamples DEPENDS mpexample mpcalculator mpprinter)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_TESTING AND TARGET CapnProto::kj-test)
   target_capnp_sources(mptest ${CMAKE_CURRENT_SOURCE_DIR} mp/test/foo.capnp)
   target_include_directories(mptest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   target_link_libraries(mptest PRIVATE CapnProto::kj-test)
-  target_link_libraries(mptest PRIVATE Threads::Threads)
+  target_link_libraries(mptest PRIVATE mpdeps)
 
   add_dependencies(mptests mptest)
   add_test(NAME mptest COMMAND mptest)


### PR DESCRIPTION
Make `find_package(Threads)` optional because there are platforms where this package may not be required, and because `find_package(Threads REQUIRED)` errors obscure more detailed error messages and make issues harder to debug.

There errors can happen on different platforms with different cmake policy settings. See commit message for details.