### PR TITLE
cmake: Disable automatic C++20 module dependency scanning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(CMAKE_CXX_STANDARD_REQUIRED YES)
 endif()
 
+# Disable automatic C++20 module dependency scanning.
+# CMake >=3.28 tries to use `clang-scan-deps` by default, which may not
+# be installed on all platforms. We don't use named modules, so turn this off.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 include("cmake/compat_find.cmake")
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Set `CMAKE_CXX_SCAN_FOR_MODULES` off because this project doesn't use C++ modules, and they are enabled by default in newer versions of cmake, which can lead to failures trying to invoke the `clang-scan-deps` tool if it is not installed.