### PR TITLE
ci: Remove hard-coded -j4 from sanitize config

### DIFF
--- a/ci/configs/sanitize.bash
+++ b/ci/configs/sanitize.bash
@@ -4,5 +4,5 @@ NIX_ARGS=(--arg enableLibcxx true --argstr libcxxSanitizers "Thread" --argstr ca
 export CXX=clang++
 export CXXFLAGS="-ggdb -Werror -Wall -Wextra -Wpedantic -Wthread-safety -Wno-unused-parameter -fsanitize=thread -Wno-c++23-lambda-attributes"
 CMAKE_ARGS=()
-BUILD_ARGS=(-k -j4)
+BUILD_ARGS=(-k)
 BUILD_TARGETS=(mptest)


### PR DESCRIPTION
Not needed after CMAKE_BUILD_PARALLEL_LEVEL is set to nproc.