### PR TITLE
doc: Update Cap'n Proto version to match minimum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(CAPNPROTO_CVE_AFFECTED OR CAPNPROTO_CLANG_INCOMPATIBLE)
   string(APPEND RESOLUTION_OPTIONS "  - Upgrade to Cap'n Proto version 1.0 or newer (recommended)\n")
 
   if(CAPNPROTO_CVE_AFFECTED AND NOT CAPNPROTO_CLANG_INCOMPATIBLE)
-    string(APPEND RESOLUTION_OPTIONS "  - Upgrade to a patched minor version (0.7.1, 0.8.1, 0.9.2, 0.10.3, or later)\n")
+    string(APPEND RESOLUTION_OPTIONS "  - Upgrade to a patched minor version (0.9.2, 0.10.3, or later)\n")
   elseif(CAPNPROTO_CLANG_INCOMPATIBLE AND NOT CAPNPROTO_CVE_AFFECTED)
     string(APPEND RESOLUTION_OPTIONS "  - Use GCC instead of Clang\n")
   endif()

--- a/doc/install.md
+++ b/doc/install.md
@@ -1,6 +1,6 @@
 # libmultiprocess Installation
 
-Installation currently requires Cap'n Proto 0.7 or higher:
+Installation currently requires Cap'n Proto 0.9 or higher:
 
 ```sh
 apt install libcapnp-dev capnproto


### PR DESCRIPTION
This was overlooked in https://github.com/bitcoin-core/libmultiprocess/pull/331.