### PR TITLE
ci: bump cmake version to 4.3.4 in newdeps job

### DIFF
--- a/ci/configs/newdeps.bash
+++ b/ci/configs/newdeps.bash
@@ -2,5 +2,5 @@ CI_DESC="CI job using newest Cap'n Proto and cmake versions"
 CI_DIR=build-newdeps
 export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
 CAPNP_CHECKOUT=master
-NIX_ARGS=(--argstr capnprotoVersion "none" --argstr cmakeVersion "4.1.1")
+NIX_ARGS=(--argstr capnprotoVersion "none" --argstr cmakeVersion "4.3.4")
 BUILD_ARGS=(-k)

--- a/ci/configs/newdeps.bash
+++ b/ci/configs/newdeps.bash
@@ -1,6 +1,6 @@
 CI_DESC="CI job using newest Cap'n Proto and cmake versions"
 CI_DIR=build-newdeps
 export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
-CAPNP_CHECKOUT=master
+CAPNP_CHECKOUT=master  # This is the v1.x release branch
 NIX_ARGS=(--argstr capnprotoVersion "none" --argstr cmakeVersion "4.3.4")
 BUILD_ARGS=(-k)

--- a/shell.nix
+++ b/shell.nix
@@ -56,6 +56,7 @@ let
   cmakeHashes = {
     "3.12.4" = "sha256-UlVYS/0EPrcXViz/iULUcvHA5GecSUHYS6raqbKOMZQ=";
     "4.1.1" = "sha256-sp9vGXM6oiS3djUHoQikJ+1Ixojh+vIrKcROHDBUkoI=";
+    "4.3.4" = "sha256-/e/4l7nrSddkU58rHtxut+FEDfMlZ4qXwZeEmekxrdo=";
   };
   gcc = if gccVersion == null then null else builtins.getAttr ("gcc" + gccVersion) pkgs;
   cmakeBuild = if cmakeVersion == null then pkgs.cmake else (pkgs.cmake.overrideAttrs (old: {


### PR DESCRIPTION
Update cmake from 4.1.1 to 4.3.4 and add capnproto branch comment as suggested in https://github.com/bitcoin-core/libmultiprocess/pull/212 reviews