### PR TITLE
pull latest .clang-tidy from downstream

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,8 +6,12 @@ bugprone-string-constructor,
 bugprone-use-after-move,
 bugprone-lambda-function-name,
 bugprone-unhandled-self-assignment,
-misc-unused-using-decls,
+bugprone-unused-return-value,
+fuchsia-header-anon-namespaces,
+misc-definitions-in-headers,
 misc-no-recursion,
+misc-unused-using-decls,
+modernize-avoid-bind,
 modernize-deprecated-headers,
 modernize-use-default-member-init,
 modernize-use-emplace,
@@ -22,6 +26,7 @@ performance-*,
 -performance-no-int-to-ptr,
 -performance-noexcept-move-constructor,
 -performance-unnecessary-value-param,
+readability-avoid-const-params-in-decls,
 readability-const-return-type,
 readability-container-contains,
 readability-redundant-declaration,
@@ -36,6 +41,10 @@ CheckOptions:
  - key: modernize-deprecated-headers.CheckHeaderFile
    value: false
  - key: performance-move-const-arg.CheckTriviallyCopyableMove
-   value: false
+   value: false  # Disabled, to allow the bugprone-use-after-move rule on trivially copyable types, to catch logic bugs
  - key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
    value: false
+ - key: bugprone-unused-return-value.CheckedReturnTypes
+   value: '^::std::error_code$;^::std::error_condition$;^::std::errc$;^::std::expected$;^::util::Result$;^::util::Expected$'
+ - key: bugprone-unused-return-value.AllowCastToVoid
+   value: true  # Can be removed with C++26 once the _ placeholder exists.


### PR DESCRIPTION
Seems fine to do after https://github.com/bitcoin-core/libmultiprocess/pull/358, given that it is passing CI