### PR TITLE
util: Error out at compile time if KJ_NO_EXCEPTIONS is set

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -13,6 +13,12 @@
 #include <typeindex>
 #include <vector>
 
+// KJ exception support is required, or exceptions thrown in serverInvoke below go uncaught
+// and crash the process instead of being returned to the client as errors.
+#if KJ_NO_EXCEPTIONS
+#error "KJ_NO_EXCEPTIONS=1 is set but libmultiprocess requires support for exceptions. Please check build settings. On NetBSD you may also need to set -DKJ_NO_EXCEPTIONS=0 -DKJ_NO_RTTI=0 explicitly (https://github.com/capnproto/capnproto/pull/2756)"
+#endif
+
 namespace mp {
 
 template <typename Value>


### PR DESCRIPTION
Cap'n Proto has a bug on netbsd where it incorrectly detects compiler does not support exceptions (reported and fixed in https://github.com/capnproto/capnproto/pull/2756) causing exceptions thrown from bitcoin core IPC methods not be caught and leading to the CI failure reported https://github.com/bitcoin/bitcoin/issues/36058.

Failure can be worked around by adding `-DKJ_NO_EXCEPTIONS=0`` to the build configuration so add an error message to detect when it would happen and suggest this.

